### PR TITLE
Reduce reliance on Enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - mix deps.get --only test
 script:
   - mix test
-  - dialyzer --no_check_plt --plt $PLT_LOCATION -Wno_match --no_native _build/test/lib/ex_twilio/ebin
+  - dialyzer --no_check_plt --plt $PLT_LOCATION -Wno_match -Wno_return --no_native _build/test/lib/ex_twilio/ebin
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report

--- a/lib/ex_twilio/resource.ex
+++ b/lib/ex_twilio/resource.ex
@@ -50,7 +50,7 @@ defmodule ExTwilio.Resource do
       variable = String.downcase(resource) |> Inflex.pluralize
       variable_singular = Inflex.singularize(variable)
 
-      if Enum.member? import_functions, :stream do
+      if :stream in import_functions do
         @doc """
         Create a stream of all #{resource} records from the Twilio API.
 
@@ -60,7 +60,7 @@ defmodule ExTwilio.Resource do
         def stream(options \\ []), do: Api.stream(__MODULE__, options)
       end
 
-      if Enum.member? import_functions, :all do
+      if :all in import_functions do
         @doc """
         Retrieve _all_ of the #{resource} records from the Twilio API, paging
         through all the API response pages.
@@ -75,7 +75,7 @@ defmodule ExTwilio.Resource do
         def all(options \\ []), do: Api.all(__MODULE__, options)
       end
 
-      if Enum.member? import_functions, :list do
+      if :list in import_functions do
         @doc """
         Retrieve a list of #{Inflex.pluralize resource} from the API. 
 
@@ -157,7 +157,7 @@ defmodule ExTwilio.Resource do
         end
       end
 
-      if Enum.member? import_functions, :find do
+      if :find in import_functions do
         @doc """
         Find any #{resource} by its Twilio SID.
 
@@ -172,7 +172,7 @@ defmodule ExTwilio.Resource do
         def find(sid, options \\ []), do: Api.find(__MODULE__, sid, options)
       end
 
-      if Enum.member? import_functions, :create do
+      if :create in import_functions do
         @doc """
         Create a new #{resource} in the Twilio API. Any field supported by
         Twilio's #{resource} API can be passed in the 'data' keyword list.
@@ -183,7 +183,7 @@ defmodule ExTwilio.Resource do
         def create(data, options \\ []), do: Api.create(__MODULE__, data, options)
       end
 
-      if Enum.member? import_functions, :update do
+      if :update in import_functions do
         @doc """
         Update an #{resource} in the Twilio API. You can pass it a binary SID as
         the identifier, or a whole %#{module}{} struct.
@@ -199,7 +199,7 @@ defmodule ExTwilio.Resource do
         def update(sid, data, options \\ []), do: Api.update(__MODULE__, sid, data, options)
       end
 
-      if Enum.member? import_functions, :destroy do
+      if :destroy in import_functions do
         @doc """
         Delete any #{resource} from your Twilio account, using its SID.
 

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -75,8 +75,7 @@ defmodule ExTwilio.UrlGenerator do
   """
   @spec to_query_string(list) :: String.t
   def to_query_string(list) do
-    Enum.map(list, fn {key, value} -> {camelize(key), value} end)
-    |> Enum.into(%{})
+    for({key, value} <- list, into: %{}, do: {camelize(key), value})
     |> URI.encode_query
   end
 
@@ -114,7 +113,7 @@ defmodule ExTwilio.UrlGenerator do
 
   @spec build_query(list) :: String.t
   defp build_query(options) do
-    query = Enum.reject(options, fn({key, _val}) -> Enum.member?(@special, key) end)
+    query = Enum.reject(options, fn({key, _val}) -> key in @special end)
             |> to_query_string
 
     if String.length(query) > 0, do: "?" <> query, else: query
@@ -122,9 +121,7 @@ defmodule ExTwilio.UrlGenerator do
 
   @spec build_segments(list, list) :: String.t
   defp build_segments(allowed_keys, list) do
-    Enum.reduce allowed_keys, "", fn key, acc -> 
-      acc <> segment({key, list[key]})
-    end
+    for key <- allowed_keys, into: "", do: segment({key, list[key]})
   end
 
   @spec segment({atom, any}, list) :: String.t

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExTwilio.Mixfile do
      source_url: "https://github.com/danielberkompas/ex_twilio",
      dialyzer: [
        plt_file: "#{System.get_env("HOME")}/#{plt_filename}",
-       flags: ["--no_native", "-Wno_match"]
+       flags: ["--no_native", "-Wno_match", "-Wno_return"]
      ],
      deps: deps]
   end


### PR DESCRIPTION
Elixir has built-in language features which do some tasks more elegantly
than the Enum module. This PR refactors the code in favor of those.