### PR TITLE
Refactor `stream` function, remove list functions

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -1,11 +1,4 @@
 defmodule ExTwilio.Api do
-  use HTTPotion.Base
-
-  alias ExTwilio.Config
-  alias ExTwilio.Parser
-  alias ExTwilio.UrlGenerator, as: Url
-  alias __MODULE__ # Necessary for mocks in tests
-
   @moduledoc """
   Provides a basic HTTP interface to allow easy communication with the Twilio
   API, by wrapping `HTTPotion`.
@@ -13,161 +6,50 @@ defmodule ExTwilio.Api do
   ## Examples
 
   Requests are made to the Twilio API by passing in a resource module into one
-  of this `Api` module's many functions. The correct URL to the resource is
-  inferred from the module name.
+  of this `Api` module's functions. The correct URL to the resource is inferred
+  from the module name.
 
-      ExTwilio.Api.all(Resource)
-      [%Resource{ ... }, %Resource{ ... }]
+      ExTwilio.Api.find(Resource, "sid")
+      %Resource{ sid: "sid", ... }
 
   Items are returned as instances of the given module's struct. For more
   details, see the documentation for each function.
   """
 
-  @doc """
-  Seamlessly stream through all available pages of a resource with `stream/2`.
-  Pages will be requested lazily, allowing you to start processing as soon as
-  the first page of results is returned.
+  use HTTPotion.Base
 
-  Page size will affect the number of requests made to Twilio to get the entire
-  collection, so it can be configured with the `page_size` option.
-
-  ## Examples
-
-      stream = ExTwilio.Api.stream(ExTwilio.Call, page_size: 1)
-      Enum.each stream, fn(call) ->
-        IO.puts "We made a call to #\{call.to\}!"
-      end
-
-      # Collapse the stream into a list. List will not be returned until all
-      # pages have been fetched from Twilio.
-      Enum.into stream, []
-      [%Call{ ... }, %Call{ ... }, ...]
-
-      # Progressively build filters with the Pipe operator.
-      ExTwilio.Api.stream(ExTwilio.Call)
-      |> Stream.filter fn(call) -> call.duration > 120 end
-      |> Stream.map    fn(call) -> call.sid end
-      |> Enum.into [] # Only here is the stream actually executed
-  """
-  @spec stream(module, list) :: Enumerable.t
-  def stream(module, options \\ []) do
-    start = fn ->
-      case list(module, options) do
-        {:ok, items, meta} -> {items, meta["next_page_uri"], options}
-        _                  -> {[], nil, []}
-      end
-    end
-
-    pop_item = fn {[head|tail], next, options} ->
-      new_state = {tail, next, options}
-      {[head], new_state}
-    end
-
-    fetch_next_page = fn module, state = {[], next_page, options} ->
-      case fetch_page(module, next_page, options) do
-        {:ok, items, meta} -> pop_item.({items, meta["next_page_uri"], options})
-        _error             -> {:halt, state}
-      end
-    end
-
-    next_item = fn state = {[], nil, _}       -> {:halt, state}
-                   state = {[], _next, _opts} -> fetch_next_page.(module, state)
-                   state                      -> pop_item.(state)
-    end
-
-    stop = fn (_) -> end
-
-    Stream.resource(start, next_item, stop)
-  end
-
-  @doc """
-  Return **all** the resources available for a given Twilio resource.
-
-  **Important**: Since there may be many pages of results, this function has the
-  potential to block your process for a long time. Therefore, be _very_ careful.
-  Whenever possible, you should use `stream/2` or `list/2`.
-
-  ## Examples
-
-      ExTwilio.Api.all(ExTwilio.Call)
-      [%Call{ ... }, %Call{ ... }, ...]
-
-  If you want the function to take less time, you can increase the size of the
-  pages returned by Twilio. This will reduce the number of requests.
-
-      ExTwilio.Api.all(ExTwilio.Call, page_size: 100)
-  """
-  @spec all(atom, list) :: [map]
-  def all(module, options \\ []) do
-    Enum.into stream(module, options), []
-  end
-
-  @doc """
-  Get the first page of results for a given resource. Page size is configurable
-  with the `page_size` option. For paging through multiple pages, see one of
-  these functions:
-
-  - `fetch_page/2`
-  - `all/0`
-  - `stream/2`
-
-  ## Examples
-
-      {:ok, list, meta} = ExTwilio.Api.list(ExTwilio.Call, page_size: 1)
-  """
-  @spec list(atom, list) :: Parser.success_list | Parser.error
-  def list(module, options \\ []) do
-    url = Url.build_url(module, nil, options)
-    do_list(module, url)
-  end
-
-  @spec do_list(module, String.t) :: Parser.success_list | Parser.error
-  defp do_list(module, url) do
-    Parser.parse_list(module, Api.get(url), module.resource_collection_name)
-  end
-
-  @doc """
-  Fetch a particular page of results from the API, using a page URL provided by
-  Twilio in its pagination metadata.
-
-  ## Example
-
-      {:ok, list, meta} = ExTwilio.Api.list(ExTwilio.Call)
-      {:ok, next_page, meta} = ExTwilio.Api.next_page(ExTwilio.Call, meta["next_page_uri"])
-  """
-  @spec fetch_page(atom, (String.t | nil), list) :: Parser.success_list | Parser.error
-  def fetch_page(module, path, options \\ [])
-  def fetch_page(_module, nil, _options), do: {:error, "That page does not exist."}
-  def fetch_page(module, path, options) do
-    uri = Config.base_url <> path |> String.to_char_list
-
-    case :http_uri.parse(uri) do
-      {:ok, {_, _, _, _, _, query}} -> 
-        url = Url.build_url(module, nil, Dict.put(options, :query, String.Chars.to_string(query)))
-        do_list(module, url)
-      {:error, _reason} -> 
-        {:error, "Next page URI '#{uri}' was not properly formatted."}
-    end
-  end
+  alias ExTwilio.Config
+  alias ExTwilio.Parser
+  alias ExTwilio.UrlGenerator, as: Url
+  alias __MODULE__ # Necessary for mocks in tests
 
   @doc """
   Find a given resource in the Twilio API by its SID.
 
   ## Examples
 
+  If the resource was found, `find/2` will return a two-element tuple in this
+  format, `{:ok, item}`.
+
       ExTwilio.Api.find(ExTwilio.Call, "<sid here>")
       {:ok, %Call{ ... }}
+
+  If the resource could not be loaded, `find/2` will return a 3-element tuple
+  in this format, `{:error, message, code}`. The `code` is the HTTP status code
+  returned by the Twilio API, for example, 404.
 
       ExTwilio.Api.find(ExTwilio.Call, "nonexistent sid")
       {:error, "The requested resource couldn't be found...", 404}
   """
   @spec find(atom, String.t | nil, list) :: Parser.success | Parser.error
   def find(module, sid, options \\ []) do
-    Parser.parse module, Api.get(Url.build_url(module, sid, options))
+    Url.build_url(module, sid, options) 
+    |> Api.get
+    |> Parser.parse(module)
   end
 
   @doc """
-  Create a new resource in the Twilio API.
+  Create a new resource in the Twilio API with a POST request.
 
   ## Examples
 
@@ -179,7 +61,9 @@ defmodule ExTwilio.Api do
   """
   @spec create(atom, list, list) :: Parser.success | Parser.error
   def create(module, data, options \\ []) do
-    Parser.parse module, Api.post(Url.build_url(module, nil, options), body: data)
+    Url.build_url(module, nil, options) 
+    |> Api.post(body: data)
+    |> Parser.parse(module)
   end
 
   @doc """
@@ -198,7 +82,9 @@ defmodule ExTwilio.Api do
   def update(module, sid, data, options) when is_binary(sid), do: do_update(module, sid, data, options)
   def update(module, %{sid: sid}, data, options),             do: do_update(module, sid, data, options)
   defp do_update(module, sid, data, options) do
-    Parser.parse module, Api.post(Url.build_url(module, sid, options), body: data)
+    Url.build_url(module, sid, options)
+    |> Api.post(body: data)
+    |> Parser.parse(module)
   end
 
   @doc """
@@ -217,7 +103,9 @@ defmodule ExTwilio.Api do
   def destroy(module, sid, options) when is_binary(sid), do: do_destroy(module, sid, options)
   def destroy(module, %{sid: sid}, options),             do: do_destroy(module, sid, options)
   defp do_destroy(module, sid, options) do
-    Parser.parse module, Api.delete(Url.build_url(module, sid, options))
+    Url.build_url(module, sid, options)
+    |> Api.delete
+    |> Parser.parse(module)
   end
 
   ###

--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -41,7 +41,7 @@ defmodule ExTwilio.Parser do
       ...> ExTwilio.Parser.parse(response, %{})
       {:ok, %{"sid" => "AD34123"}}
   """
-  @spec parse(atom, response) :: success | error
+  @spec parse(response, module) :: success | error
   def parse(response, module) do
     handle_errors response, fn(body) ->
       Poison.decode!(body, as: module)
@@ -77,7 +77,7 @@ defmodule ExTwilio.Parser do
       ExTwilio.Parser.parse_list(Resource, json, "resources")
       {:ok, [%Resource{sid: "first"}, %Resource{sid: "second"}], %{"next_page" => 10}}
   """
-  @spec parse_list(atom, response, key) :: success_list | error
+  @spec parse_list(response, module, key) :: success_list | error
   def parse_list(response, module, key) do
     result = handle_errors response, fn(body) ->
       as = Dict.put(%{}, key, [module])

--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -32,17 +32,17 @@ defmodule ExTwilio.Parser do
   You can parse JSON into that module's struct like so:
 
       iex> response = %{body: "{ \\"sid\\": \\"AD34123\\" }", status_code: 200}
-      ...> ExTwilio.Parser.parse(Resource, response)
+      ...> ExTwilio.Parser.parse(response, Resource)
       {:ok, %Resource{sid: "AD34123"}}
 
   You can also parse into a regular map if you want.
 
       iex> response = %{body: "{ \\"sid\\": \\"AD34123\\" }", status_code: 200}
-      ...> ExTwilio.Parser.parse(%{}, response)
+      ...> ExTwilio.Parser.parse(response, %{})
       {:ok, %{"sid" => "AD34123"}}
   """
   @spec parse(atom, response) :: success | error
-  def parse(module, response) do
+  def parse(response, module) do
     handle_errors response, fn(body) ->
       Poison.decode!(body, as: module)
     end

--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -78,7 +78,7 @@ defmodule ExTwilio.Parser do
       {:ok, [%Resource{sid: "first"}, %Resource{sid: "second"}], %{"next_page" => 10}}
   """
   @spec parse_list(atom, response, key) :: success_list | error
-  def parse_list(module, response, key) do
+  def parse_list(response, module, key) do
     result = handle_errors response, fn(body) ->
       as = Dict.put(%{}, key, [module])
       Poison.decode!(body, as: as)

--- a/lib/ex_twilio/resource.ex
+++ b/lib/ex_twilio/resource.ex
@@ -61,7 +61,6 @@ defmodule ExTwilio.Resource do
         Create an `ExTwilio.ResultStream` of all #{resource} records from the 
         Twilio API.
         """
-        @spec stream(list) :: Stream.t
         def stream(options \\ []), do: ResultStream.new(__MODULE__, options)
       end
 

--- a/lib/ex_twilio/resources/account.ex
+++ b/lib/ex_twilio/resources/account.ex
@@ -33,7 +33,7 @@ defmodule ExTwilio.Account do
             uri: nil,
             subresource_uris: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update]
 
   @doc """
   Suspend an Account by updating its status to "suspended".

--- a/lib/ex_twilio/resources/address.ex
+++ b/lib/ex_twilio/resources/address.ex
@@ -15,7 +15,7 @@ defmodule ExTwilio.Address do
             postal_code: nil,
             iso_country: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :create, :find, :update]
+  use ExTwilio.Resource, import: [:stream, :all, :create, :find, :update]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/application.ex
+++ b/lib/ex_twilio/resources/application.ex
@@ -25,7 +25,7 @@ defmodule ExTwilio.Application do
             message_status_callback: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/authorized_connect_app.ex
+++ b/lib/ex_twilio/resources/authorized_connect_app.ex
@@ -16,7 +16,7 @@ defmodule ExTwilio.AuthorizedConnectApp do
             connect_app_homepage_url: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find]
+  use ExTwilio.Resource, import: [:stream, :all, :find]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/available_phone_number.ex
+++ b/lib/ex_twilio/resources/available_phone_number.ex
@@ -17,7 +17,7 @@ defmodule ExTwilio.AvailablePhoneNumber do
             capabilities: nil,
             address_requirements: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list]
+  use ExTwilio.Resource, import: [:stream, :all]
 
   def parents, do: [:account]
   def children, do: [:iso_country_code, :type]

--- a/lib/ex_twilio/resources/call.ex
+++ b/lib/ex_twilio/resources/call.ex
@@ -24,7 +24,7 @@ defmodule ExTwilio.Call do
             caller_name: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def cancel(%{sid: sid}), do: cancel(sid)
   def cancel(sid),         do: update(sid, status: "canceled")

--- a/lib/ex_twilio/resources/conference.ex
+++ b/lib/ex_twilio/resources/conference.ex
@@ -13,7 +13,7 @@ defmodule ExTwilio.Conference do
             account_sid: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find]
+  use ExTwilio.Resource, import: [:stream, :all, :find]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/connect_app.ex
+++ b/lib/ex_twilio/resources/connect_app.ex
@@ -19,7 +19,7 @@ defmodule ExTwilio.ConnectApp do
             deauthorize_callback_method: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/dependent_phone_number.ex
+++ b/lib/ex_twilio/resources/dependent_phone_number.ex
@@ -22,7 +22,7 @@ defmodule ExTwilio.DependentPhoneNumber do
             postal_code: nil,
             iso_country: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list]
+  use ExTwilio.Resource, import: [:stream, :all]
 
   def parents, do: [:account, :address]
 end

--- a/lib/ex_twilio/resources/incoming_phone_number.ex
+++ b/lib/ex_twilio/resources/incoming_phone_number.ex
@@ -28,7 +28,7 @@ defmodule ExTwilio.IncomingPhoneNumber do
             address_requirements: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/media.ex
+++ b/lib/ex_twilio/resources/media.ex
@@ -20,7 +20,7 @@ defmodule ExTwilio.Media do
             content_type: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy]
 
   def resource_name, do: "Media"
   def resource_collection_name, do: "media_list"

--- a/lib/ex_twilio/resources/member.ex
+++ b/lib/ex_twilio/resources/member.ex
@@ -17,7 +17,7 @@ defmodule ExTwilio.Member do
             wait_time: nil,
             position: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :update]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :update]
 
   def parents, do: [:account, :queue]
 end

--- a/lib/ex_twilio/resources/message.ex
+++ b/lib/ex_twilio/resources/message.ex
@@ -25,7 +25,7 @@ defmodule ExTwilio.Message do
             uri: nil,
             subresource_uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/notification.ex
+++ b/lib/ex_twilio/resources/notification.ex
@@ -23,7 +23,7 @@ defmodule ExTwilio.Notification do
             response_body: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy]
 
   def parents, do: [:account, :call]
 end

--- a/lib/ex_twilio/resources/outgoing_caller_id.ex
+++ b/lib/ex_twilio/resources/outgoing_caller_id.ex
@@ -15,7 +15,7 @@ defmodule ExTwilio.OutgoingCallerId do
             call_sid: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/participant.ex
+++ b/lib/ex_twilio/resources/participant.ex
@@ -22,7 +22,7 @@ defmodule ExTwilio.Participant do
             end_conference_on_exit: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :list, :all, :find, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :update, :destroy]
 
   def parents, do: [:account, :conference]
 end

--- a/lib/ex_twilio/resources/queue.ex
+++ b/lib/ex_twilio/resources/queue.ex
@@ -11,7 +11,7 @@ defmodule ExTwilio.Queue do
             max_size: nil,
             average_wait_time: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/recording.ex
+++ b/lib/ex_twilio/resources/recording.ex
@@ -14,7 +14,7 @@ defmodule ExTwilio.Recording do
             api_version: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/short_code.ex
+++ b/lib/ex_twilio/resources/short_code.ex
@@ -18,7 +18,7 @@ defmodule ExTwilio.ShortCode do
             sms_fallback_url_method: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :update]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :update]
 
   def resource_name, do: "SMS/ShortCodes"
   def parents, do: [:account]

--- a/lib/ex_twilio/resources/sip_credential.ex
+++ b/lib/ex_twilio/resources/sip_credential.ex
@@ -13,7 +13,7 @@ defmodule ExTwilio.SipCredential do
             date_updated: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def resource_name, do: "Credentials"
   def resource_collection_name, do: "credentials"

--- a/lib/ex_twilio/resources/sip_credential_list.ex
+++ b/lib/ex_twilio/resources/sip_credential_list.ex
@@ -12,7 +12,7 @@ defmodule ExTwilio.SipCredentialList do
             date_updated: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def resource_name, do: "SIP/CredentialLists"
   def resource_collection_name, do: "credential_lists"

--- a/lib/ex_twilio/resources/sip_domain.ex
+++ b/lib/ex_twilio/resources/sip_domain.ex
@@ -21,7 +21,7 @@ defmodule ExTwilio.SipDomain do
             date_updated: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def resource_name, do: "SIP/Domains"
   def resource_collection_name, do: "domains"

--- a/lib/ex_twilio/resources/sip_ip_access_control_list.ex
+++ b/lib/ex_twilio/resources/sip_ip_access_control_list.ex
@@ -12,7 +12,7 @@ defmodule ExTwilio.SipIpAccessControlList do
             date_updated: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def resource_name, do: "SIP/IpAccessControlLists"
   def resource_collection_name, do: "ip_access_control_lists"

--- a/lib/ex_twilio/resources/sip_ip_address.ex
+++ b/lib/ex_twilio/resources/sip_ip_address.ex
@@ -13,7 +13,7 @@ defmodule ExTwilio.SipIpAddress do
             date_updated: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :create, :update, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :destroy]
 
   def resource_name, do: "IpAddresses"
   def resource_collection_name, do: "ip_addresses"

--- a/lib/ex_twilio/resources/token.ex
+++ b/lib/ex_twilio/resources/token.ex
@@ -13,7 +13,7 @@ defmodule ExTwilio.Token do
             date_created: nil,
             date_updated: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :create]
+  use ExTwilio.Resource, import: [:stream, :all, :create]
 
   def parents, do: [:account]
 end

--- a/lib/ex_twilio/resources/transcription.ex
+++ b/lib/ex_twilio/resources/transcription.ex
@@ -17,7 +17,7 @@ defmodule ExTwilio.Transcription do
             price_unit: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :list, :find, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy]
 
   def parents, do: [:account, :recording]
 end

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -29,7 +29,6 @@ defmodule ExTwilio.ResultStream do
 
       ExTwilio.ResultStream.new(ExTwilio.Call)
   """
-  @spec new(module) :: Stream.t
   def new(module, options \\ []) do
     url = UrlGenerator.build_url(module, nil, options)
 

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -43,7 +43,7 @@ defmodule ExTwilio.ResultStream do
   @spec fetch_page(url, module) :: {list, url, module}
   defp fetch_page(url, module) do
     results = Api.get(url)
-    {:ok, items, meta} = Parser.parse_list(module, results, module.resource_collection_name)
+    {:ok, items, meta} = Parser.parse_list(results, module, module.resource_collection_name)
     {items, meta["next_page_uri"], module}
   end
 

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -1,0 +1,65 @@
+defmodule ExTwilio.ResultStream do
+  @moduledoc """
+  Generate a stream of results for a given Twilio API URL. Pages are lazily
+  loaded on demand.
+
+  ## Example
+
+      ExTwilio.ResultStream.new(ExTwilio.Call)
+      |> Stream.map(fn call -> call.sid end)
+      |> Enum.take(5)
+
+      # => [%ExTwilio.Call{ ... }, %ExTwilio.Call{ ... }, ...]
+  """
+
+  alias ExTwilio.Api
+  alias ExTwilio.Parser
+  alias ExTwilio.UrlGenerator
+
+  @type url :: String.t
+
+  @doc """
+  Create a new Stream.
+
+  ## Parameters
+
+  - `module`: The name of the module to create a Stream of results for.
+
+  ## Example
+
+      ExTwilio.ResultStream.new(ExTwilio.Call)
+  """
+  @spec new(module) :: Stream.t
+  def new(module, options \\ []) do
+    url = UrlGenerator.build_url(module, nil, options)
+
+    Stream.resource(
+      fn -> fetch_page(url, module) end,
+      &process_page/1,
+      fn _ -> end
+    )
+  end
+
+  @spec fetch_page(url, module) :: {list, url, module}
+  defp fetch_page(url, module) do
+    results = Api.get(url)
+    {:ok, items, meta} = Parser.parse_list(module, results, module.resource_collection_name)
+    {items, meta["next_page_uri"], module}
+  end
+
+  @spec process_page({list | nil, url | nil, module}) :: {:halt, nil} |
+                                                         {list, {nil, url, module}}
+  defp process_page({nil, nil, _module}) do
+    {:halt, nil}
+  end
+
+  defp process_page({nil, next_page_url, module}) do
+    next_page_url
+    |> fetch_page(module)
+    |> process_page
+  end
+
+  defp process_page({items, next_page_url, module}) do
+    {items, {nil, next_page_url, module}}
+  end
+end

--- a/test/ex_twilio/api_test.exs
+++ b/test/ex_twilio/api_test.exs
@@ -14,49 +14,6 @@ defmodule ExTwilio.ApiTest do
 
   doctest ExTwilio.Api
 
-  test ".stream should automatically page through resources, yielding each resource" do
-    page1 = %{
-      "resources" => [
-        %{sid: "1", name: "first"}, 
-      ],
-      next_page_uri: "?Page=2"
-    }
-
-    page2 = %{
-      "resources" => [
-        %{sid: "2", name: "second"}, 
-      ],
-      next_page_uri: nil
-    }
-
-    with_fixture {:get, fn url ->
-                            if String.match?(url, ~r/\?Page=2/) do
-                              json_response(page2, 200)
-                            else
-                              json_response(page1, 200)
-                            end
-                        end}, fn ->
-      expected = [%Resource{sid: "1", name: "first"}, %Resource{sid: "2", name: "second"}]
-      assert expected == Enum.into Api.stream(Resource), []
-    end
-  end
-
-  test ".list should fetch the first page of results" do
-    with_list_fixture fn(expected) ->
-      assert expected == Api.list(Resource)
-    end
-  end
-
-  test ".fetch_page should fetch a page of results, given a page url" do
-    with_list_fixture fn(expected) ->
-      assert expected == Api.fetch_page(Resource, "next_page_path")
-    end
-  end
-
-  test ".fetch_page should return an error if passed a nil path" do
-    assert {:error, "That page does not exist."} == Api.fetch_page(Resource, nil)
-  end
-
   test ".find should return the resource if it exists" do
     json = json_response(%{sid: "id"}, 200)
 

--- a/test/ex_twilio/parser_test.exs
+++ b/test/ex_twilio/parser_test.exs
@@ -8,20 +8,20 @@ defmodule ExTwilio.ParserTest do
 
   doctest ExTwilio.Parser
 
-  #test ".parse should decode a successful response into a named struct" do
-    #response = %{body: "{ \"sid\": \"unique_id\" }", status_code: 200}
-    #assert {:ok, %Resource{sid: "unique_id"}} == parse(response, Resource)
-  #end
+  test ".parse should decode a successful response into a named struct" do
+    response = %{body: "{ \"sid\": \"unique_id\" }", status_code: 200}
+    assert {:ok, %Resource{sid: "unique_id"}} == parse(response, Resource)
+  end
 
-  #test ".parse should return an error when response is 400" do
-    #response = %{body: "{ \"message\": \"Error message\" }", status_code: 400}
-    #assert {:error, "Error message", 400} == parse(response, Resource)
-  #end
+  test ".parse should return an error when response is 400" do
+    response = %{body: "{ \"message\": \"Error message\" }", status_code: 400}
+    assert {:error, "Error message", 400} == parse(response, Resource)
+  end
 
-  #test ".parse should return :ok when response is 204 'No Content'" do
-    #response = %{body: "", status_code: 204}
-    #assert :ok == parse(response, Resource)
-  #end
+  test ".parse should return :ok when response is 204 'No Content'" do
+    response = %{body: "", status_code: 204}
+    assert :ok == parse(response, Resource)
+  end
   
   test ".parse_list should decode into a list of named structs" do
     json = """
@@ -38,6 +38,6 @@ defmodule ExTwilio.ParserTest do
     expected = [%Resource{sid: "first"}, %Resource{sid: "second"}]
     metadata = %{"next_page" => 10}
 
-    assert {:ok, expected, metadata} == parse_list(Resource, response, "resources")
+    assert {:ok, expected, metadata} == parse_list(response, Resource, "resources")
   end
 end

--- a/test/ex_twilio/parser_test.exs
+++ b/test/ex_twilio/parser_test.exs
@@ -8,20 +8,20 @@ defmodule ExTwilio.ParserTest do
 
   doctest ExTwilio.Parser
 
-  test ".parse should decode a successful response into a named struct" do
-    response = %{body: "{ \"sid\": \"unique_id\" }", status_code: 200}
-    assert {:ok, %Resource{sid: "unique_id"}} == parse(Resource, response)
-  end
+  #test ".parse should decode a successful response into a named struct" do
+    #response = %{body: "{ \"sid\": \"unique_id\" }", status_code: 200}
+    #assert {:ok, %Resource{sid: "unique_id"}} == parse(response, Resource)
+  #end
 
-  test ".parse should return an error when response is 400" do
-    response = %{body: "{ \"message\": \"Error message\" }", status_code: 400}
-    assert {:error, "Error message", 400} == parse(Resource, response)
-  end
+  #test ".parse should return an error when response is 400" do
+    #response = %{body: "{ \"message\": \"Error message\" }", status_code: 400}
+    #assert {:error, "Error message", 400} == parse(response, Resource)
+  #end
 
-  test ".parse should return :ok when response is 204 'No Content'" do
-    response = %{body: "", status_code: 204}
-    assert :ok == parse(Resource, response)
-  end
+  #test ".parse should return :ok when response is 204 'No Content'" do
+    #response = %{body: "", status_code: 204}
+    #assert :ok == parse(response, Resource)
+  #end
   
   test ".parse_list should decode into a list of named structs" do
     json = """

--- a/test/ex_twilio/resource_test.exs
+++ b/test/ex_twilio/resource_test.exs
@@ -26,27 +26,6 @@ defmodule ExTwilio.ResourceTest do
     assert %TestResource{sid: "hello"} == TestResource.new(sid: "hello")
   end
 
-  test ".stream should delegate to Api.stream" do
-    with_mock Api, [stream: fn(_, _) -> nil end] do
-      TestResource.stream(page_size: 1)
-      assert called Api.stream(TestResource, [page_size: 1])
-    end
-  end
-
-  test ".all should delegate to Api.all" do
-    with_mock Api, [all: fn(_, _) -> nil end] do
-      TestResource.all
-      assert called Api.all(TestResource, [])
-    end
-  end
-
-  test ".list should delegate to Api.list" do
-    with_mock Api, [list: fn(_, _) -> nil end] do
-      TestResource.list(page_size: 1)
-      assert called Api.list(TestResource, [page_size: 1])
-    end
-  end
-
   test ".find should delegate to Api.find" do
     with_mock Api, [find: fn(_, _, _) -> nil end] do
       TestResource.find("id")
@@ -72,38 +51,6 @@ defmodule ExTwilio.ResourceTest do
     with_mock Api, [destroy: fn(_, _, _) -> nil end] do
       TestResource.destroy("id")
       assert called Api.destroy(TestResource, "id", [])
-    end
-  end
-
-  test ".next_page should delegate to Api.fetch_page with 'next_page_uri'" do
-    with_mock Api, [fetch_page: fn(_, _) -> nil end] do
-      meta = %{ "next_page_uri" => "next_page" }
-      TestResource.next_page(meta)
-      assert called Api.fetch_page(TestResource, "next_page")
-    end
-  end
-
-  test ".previous_page should delegate to Api.fetch_page with 'previous_page_uri'" do
-    with_mock Api, [fetch_page: fn(_, _) -> nil end] do
-      meta = %{ "previous_page_uri" => "previous_page" }
-      TestResource.previous_page(meta)
-      assert called Api.fetch_page(TestResource, "previous_page")
-    end
-  end
-
-  test ".first_page should delegate to Api.fetch_page with 'first_page_uri'" do
-    with_mock Api, [fetch_page: fn(_, _) -> nil end] do
-      meta = %{ "first_page_uri" => "first_page" }
-      TestResource.first_page(meta)
-      assert called Api.fetch_page(TestResource, "first_page")
-    end
-  end
-
-  test ".last_page should delegate to Api.fetch_page with 'last_page_uri'" do
-    with_mock Api, [fetch_page: fn(_, _) -> nil end] do
-      meta = %{ "last_page_uri" => "last_page" }
-      TestResource.last_page(meta)
-      assert called Api.fetch_page(TestResource, "last_page")
     end
   end
 end

--- a/test/ex_twilio/result_stream_test.exs
+++ b/test/ex_twilio/result_stream_test.exs
@@ -1,0 +1,71 @@
+defmodule ExTwilio.ResultStreamTest do
+  use ExUnit.Case, async: false
+  alias ExTwilio.ResultStream
+  import TestHelper
+
+  defmodule Resource do
+    defstruct sid: nil, name: nil
+    def resource_name, do: "Resources"
+    def resource_collection_name, do: "resources"
+    def parents, do: []
+    def children, do: []
+  end
+
+  test ".new returns a new ResultStream" do
+    assert is_function ResultStream.new(Resource)
+  end
+
+  test "can return all results" do
+    with_streaming_fixture fn ->
+      expected = [%Resource{sid: "1", name: "first"}, %Resource{sid: "2", name: "second"}]
+      actual   = ResultStream.new(Resource) |> Enum.into([])
+      assert actual == expected
+    end
+  end
+
+  test "can filter results" do
+    with_streaming_fixture fn ->
+      actual = ResultStream.new(Resource)
+               |> Stream.filter(fn res -> res.name == "second" end)
+               |> Enum.take(1)
+      assert actual == [%Resource{sid: "2", name: "second"}]
+    end
+  end
+
+  test "can map results" do
+    with_streaming_fixture fn ->
+      actual = ResultStream.new(Resource)
+               |> Stream.map(fn res -> res.name end)
+               |> Enum.into([])
+      assert actual == ["first", "second"]
+    end
+  end
+
+  defp with_streaming_fixture(fun) do
+    with_fixture({:get, fn url ->
+                            if String.match?(url, ~r/\?Page=2/) do
+                              json_response(page2, 200)
+                            else
+                              json_response(page1, 200)
+                            end
+                        end}, fun)
+  end
+
+  defp page1 do
+    %{
+      "resources" => [
+        %{sid: "1", name: "first"},
+      ],
+      next_page_uri: "?Page=2"
+    }
+  end
+
+  defp page2 do
+    %{
+      "resources" => [
+        %{sid: "2", name: "second"},
+      ],
+      next_page_uri: nil
+    }
+  end
+end


### PR DESCRIPTION
The `ExTwilio.Api.stream/2` function has now become the `ExTwilio.ResultStream` module. The code is a lot more readable as a result.

With this nice `ResultStream` module in place, we don't really need the old `list` functions, since there's really no reason to interact with the paginated api directly. All the filtering that you could do can be done through `ResultStream`, and it provides a safer, more efficient interface.