### PR TITLE
 pin Poison dependency to >= 1.4 and < 2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule ExTwilio.Mixfile do
     [
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.1"},
       {:httpotion, "~> 2.1.0"},
-      {:poison, "~> 1.4.0"},
+      {:poison, "~> 1.4"},
       {:inflex, "~> 1.0.0"},
       {:mock, "~> 0.1.0", only: :test},
       {:ex_doc, "~> 0.7", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,6 @@
   "inflex": {:hex, :inflex, "1.0.0"},
   "meck": {:hex, :meck, "0.8.2"},
   "mock": {:hex, :mock, "0.1.0"},
-  "poison": {:hex, :poison, "1.4.0"},
+  "poison": {:hex, :poison, "1.5.0"},
   "quinn": {:hex, :quinn, "0.0.3"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"}}


### PR DESCRIPTION
Prior to this commit, the Poison dependency was pinned to anything in
the 1.4.x series; however, given that Poison follows semantic
versioning, we should pin to 1.x (where x >= 4) instead. This will allow
compatibility for dependency resolution when bundled with other projects
that may require a newer version of Poison, such as Phoenix.