### PR TITLE
Add missing applications to app template

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule ExTwilio.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :ibrowse, :httpotion]]
+    [applications: [:logger, :ibrowse, :httpotion, :inflex, :poison]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
All the runtime dependencies should be listed in the `applications` part - no matter if they have their own supervisors or not. Only the applications from that list are included in the releases.