### PR TITLE
Allow query strings to contain multiple values for a param

### DIFF
--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -74,7 +74,7 @@ defmodule ExTwilio.UrlGenerator do
   """
   @spec to_query_string(list) :: String.t
   def to_query_string(list) do
-    for({key, value} <- list, into: %{}, do: {camelize(key), value})
+    for({key, value} <- list, into: [], do: {camelize(key), value})
     |> URI.encode_query
   end
 

--- a/test/ex_twilio/url_generator_test.exs
+++ b/test/ex_twilio/url_generator_test.exs
@@ -9,5 +9,15 @@ defmodule ExTwilio.UrlGeneratorTest do
     def children, do: [:iso_country_code, :type]
   end
 
+  test "to_query_string does not strip out multiple params" do
+    params = [
+      {"StatusCallback", "http://example.com/status_callback"},
+      {"StatusCallbackEvent", "ringing"},
+      {"StatusCallbackEvent", "answered"},
+      {"StatusCallbackEvent", "completed"}]
+
+    assert ExTwilio.UrlGenerator.to_query_string(params) == "StatusCallback=http%3A%2F%2Fexample.com%2Fstatus_callback&StatusCallbackEvent=ringing&StatusCallbackEvent=answered&StatusCallbackEvent=completed"
+  end
+
   doctest ExTwilio.UrlGenerator
 end


### PR DESCRIPTION
Twilio requires that multiple StatusCallbackEvent params be passed as separate params; the current version of to_query_string strips multiple value for params by mapping them into a Map, which does not allow multiple values for a key.

As a sidenote, some of the doctests do not pass.