### PR TITLE
Fix Parser for Poison 2.0

### DIFF
--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -44,9 +44,12 @@ defmodule ExTwilio.Parser do
   @spec parse(response, module) :: success | error
   def parse(response, module) do
     handle_errors response, fn(body) ->
-      Poison.decode!(body, as: module)
+      Poison.decode!(body, as: target(module))
     end
   end
+
+  defp target(module) when is_atom(module), do: module.__struct__
+  defp target(other), do: other
 
   @doc """
   Parse a response expected to contain multiple resources. If you pass in a
@@ -80,7 +83,7 @@ defmodule ExTwilio.Parser do
   @spec parse_list(response, module, key) :: success_list | error
   def parse_list(response, module, key) do
     result = handle_errors response, fn(body) ->
-      as = Dict.put(%{}, key, [module])
+      as = Dict.put(%{}, key, [target(module)])
       Poison.decode!(body, as: as)
     end
 

--- a/test/ex_twilio/parser_test.exs
+++ b/test/ex_twilio/parser_test.exs
@@ -22,7 +22,7 @@ defmodule ExTwilio.ParserTest do
     response = %{body: "", status_code: 204}
     assert :ok == parse(response, Resource)
   end
-  
+
   test ".parse_list should decode into a list of named structs" do
     json = """
     {


### PR DESCRIPTION
Upgrading to Poison 2.0 broke the parser. This fixes it.