### PR TITLE
Provide full url to process_page when there is more than 50 entries.

### DIFF
--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -59,8 +59,8 @@ defmodule ExTwilio.ResultStream do
     |> process_page
   end
 
-  defp process_page({items, next_page_url, module}) do
-    {items, {nil, next_page_url, module}}
+  defp process_page({items, next_page_uri, module}) do
+    {items, {nil, next_page_uri, module}}
   end
 
   defp next_page_url(uri), do: "https://#{Config.api_domain}" <> uri

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -28,7 +28,7 @@ defmodule ExTwilio.ResultStream do
 
   ## Example
 
-  ExTwilio.ResultStream.new(ExTwilio.Call)
+      ExTwilio.ResultStream.new(ExTwilio.Call)
   """
   def new(module, options \\ []) do
     url = UrlGenerator.build_url(module, nil, options)

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -15,6 +15,7 @@ defmodule ExTwilio.ResultStream do
   alias ExTwilio.Api
   alias ExTwilio.Parser
   alias ExTwilio.UrlGenerator
+  alias ExTwilio.Config
 
   @type url :: String.t
 
@@ -27,7 +28,7 @@ defmodule ExTwilio.ResultStream do
 
   ## Example
 
-      ExTwilio.ResultStream.new(ExTwilio.Call)
+  ExTwilio.ResultStream.new(ExTwilio.Call)
   """
   def new(module, options \\ []) do
     url = UrlGenerator.build_url(module, nil, options)
@@ -52,8 +53,8 @@ defmodule ExTwilio.ResultStream do
     {:halt, nil}
   end
 
-  defp process_page({nil, next_page_url, module}) do
-    next_page_url
+  defp process_page({nil, next_page_uri, module}) do
+    next_page_url(next_page_uri)
     |> fetch_page(module)
     |> process_page
   end
@@ -61,4 +62,6 @@ defmodule ExTwilio.ResultStream do
   defp process_page({items, next_page_url, module}) do
     {items, {nil, next_page_url, module}}
   end
+
+  defp next_page_url(uri), do: "https://#{Config.api_domain}" <> uri
 end


### PR DESCRIPTION
The previous variable next_page_uri was returning the end point `/2010-04-01/Accounts/xxxxxxx/Messages.json` and causing HTTPotion to raise a HTTPotion.HTTPError because it wasn't a full url.

There are four tests failing but this is because the doc test for the url_generator don't have an account_sid and are production an empty path: ie. https://api.twilio.com/2010-04-01/Accounts//Resources.json, but expect "https://api.twilio.com/2010-04-01/Accounts/Resources.json"

I'm not sure how to test this because it only shows up contacting Twilio and you have more that 50 resources to stream.

Fixes #38