### PR TITLE
This makes ex_twilio compatible with elixir 1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule ExTwilio.Mixfile do
   defp deps do
     [
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.2.2", override: true},
-      {:httpotion, "~> 2.1"},
+      {:httpotion, "~> 3.0"},
       {:poison, ">= 2.0.0"},
       {:inflex, "~> 1.0"},
       {:mock, "~> 0.1.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "hackney": {:hex, :hackney, "1.0.6"},
   "httpoison": {:hex, :httpoison, "0.6.2"},
-  "httpotion": {:hex, :httpotion, "2.2.2"},
+  "httpotion": {:hex, :httpotion, "3.0.0"},
   "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "a1be5369c94920e3fbb8729ac81125524acb56a6", [tag: "v4.2.2"]},
   "idna": {:hex, :idna, "1.0.2"},
   "inch_ex": {:hex, :inch_ex, "0.5.1"},


### PR DESCRIPTION
As it stands, ex_twilio cannot compile, because httppotion fails with "** (ArgumentError) Access is not a protocol"