### PR TITLE
Add instructions for receiving a call in the calling tutorial

### DIFF
--- a/CALLING_TUTORIAL.md
+++ b/CALLING_TUTORIAL.md
@@ -17,9 +17,10 @@ defmodule Demo.TwilioController do
   use Demo.Web, :controller
 
   def show(conn, _params) do
-    token = ExTwilio.Capability.new
-    |> ExTwilio.Capability.allow_client_outgoing("APabe7650f654fc34655fc81ae71caa3ff")
-    |> ExTwilio.Capability.token
+    token =
+      ExTwilio.Capability.new
+      |> ExTwilio.Capability.allow_client_outgoing("APabe7650f654fc34655fc81ae71caa3ff")
+      |> ExTwilio.Capability.token
 
     render(conn, "show.html", token: token)
   end
@@ -86,4 +87,123 @@ hear the Twilio welcome message.
 
 ## Receiving a Call
 
-Pending...
+Create a controller with a `show` action and generate a Twilio capability
+token with the name _jenny_, which will allow Jenny to receive incoming calls
+
+```elixir
+defmodule Demo.TwilioController do
+  use Demo.Web, :controller
+
+  def show(conn, _params) do
+    token =
+      ExTwilio.Capability.new
+      |> ExTwilio.Capability.allow_client_incoming("jenny")
+      |> ExTwilio.Capability.token
+
+    render(conn, "show.html", token: token)
+  end
+end
+```
+
+Create a view template for the `show` action
+
+```html
+<script type="text/javascript"
+  src="//media.twiliocdn.com/sdk/js/client/v1.3/twilio.min.js"></script>
+<script type="text/javascript"
+  src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js">
+</script>
+<script type="text/javascript">
+
+/* Create the Client with a Capability Token */
+Twilio.Device.setup("<%= @token %>", {debug: true});
+
+/* Let us know when the client is ready. */
+Twilio.Device.ready(function (device) {
+    $("#log").text("Ready");
+});
+
+/* Report any errors on the screen */
+Twilio.Device.error(function (error) {
+    $("#log").text("Error: " + error.message);
+});
+
+Twilio.Device.connect(function (conn) {
+    $("#log").text("Successfully established call");
+});
+
+/* Log a message when a call disconnects. */
+Twilio.Device.disconnect(function (conn) {
+    $("#log").text("Call ended");
+});
+
+/* Listen for incoming connections */
+Twilio.Device.incoming(function (conn) {
+  $("#log").text("Incoming connection from " + conn.parameters.From);
+  // accept the incoming connection and start two-way audio
+  conn.accept();
+});
+
+/* A function to end a connection to Twilio. */
+function hangup() {
+    Twilio.Device.disconnectAll();
+}
+</script>
+
+<!-- use an onclick action to hang up the call when the user presses
+the button -->
+<button class="hangup" onclick="hangup();">
+  Hangup
+</button>
+<div id="log"></div>
+```
+
+Next, we need to create a controller action that will render some TwiML instructing Twilio to connect any incoming calls to the client named _jenny_. There is a library called [ExTwiml](https://github.com/danielberkompas/ex_twiml) that provides a nice DSL for generating TwiML with Elixir. Add it as a dependency with `{:ex_twiml, "~> 2.1.0"}`.
+
+Create the following controller action and module for rendering the TwiML
+
+```elixir
+defmodule Demo.TwilioController do
+  use Demo.Web, :controller
+
+  def show(conn, _params) do
+    token =
+      ExTwilio.Capability.new
+      |> ExTwilio.Capability.allow_client_incoming("jenny")
+      |> ExTwilio.Capability.token
+
+    render(conn, "show.html", token: token)
+  end
+
+  # Note: By default, Twilio will POST to this endpoint
+  def voice(conn, _params) do
+    resp = Demo.Twiml.dial_jenny
+    conn
+    |> put_resp_content_type("text/xml")
+    |> text(resp)
+  end
+end
+
+defmodule Demo.Twiml do
+  import ExTwiml
+
+  def dial_jenny do
+    twiml do
+      # This should be your Twilio Number or verified Caller ID
+      dial callerid: "+1XXXXXXX" do
+        client "jenny"
+      end
+    end
+  end
+end
+```
+
+Once you've started your web server, you can expose your endpoint to the world with a tool like [Ngrok](https://ngrok.com/), pointing it to your development server on port 4000
+
+`ngrok http 4000`
+
+Create a [TwiML application](https://www.twilio.com/console/voice/dev-tools/twiml-apps) on Twilio, which will tell Twilio where to get instructions for routing incoming calls. Set the URL to point to your `voice` endpoint exposed by Ngrok, e.g.
+
+`http://xxxxxxxx.ngrok.io/voice` _Note: this URL will change every time you restart Ngrok_
+
+In order to test making an inbound call to your client, you can use the `Call` button visible on the Twilio console page for your TwiML application. Open the page corresponding to the `show` action in your browser. Then, on a different computer, click the `Call` button on the Twilio console - you should be able to carry on a conversation through your browsers.

--- a/CALLING_TUTORIAL.md
+++ b/CALLING_TUTORIAL.md
@@ -200,7 +200,7 @@ end
 
 Once you've started your web server, you can expose your endpoint to the world with a tool like [Ngrok](https://ngrok.com/), pointing it to your development server on port 4000
 
-`ngrok http 4000`
+    $ ngrok http 4000
 
 Create a [TwiML application](https://www.twilio.com/console/voice/dev-tools/twiml-apps) on Twilio, which will tell Twilio where to get instructions for routing incoming calls. Set the URL to point to your `voice` endpoint exposed by Ngrok, e.g.
 

--- a/lib/ex_twilio/capability.ex
+++ b/lib/ex_twilio/capability.ex
@@ -18,7 +18,6 @@ defmodule ExTwilio.Capability do
       "xxxxx.yyyyy.zzzzz"
   """
 
-  alias ExTwilio.Capability
   alias ExTwilio.Config
 
   defstruct [
@@ -30,7 +29,7 @@ defmodule ExTwilio.Capability do
     account_sid: nil
   ]
 
-  @type capability :: %__MODULE__{
+  @type t :: %__MODULE__{
     incoming_client_names: list,
     outgoing_client_app_sid: String.t,
     ttl: non_neg_integer,
@@ -47,9 +46,9 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.new
   """
-  @spec new :: capability
+  @spec new :: t
   def new do
-    %Capability{}
+    %__MODULE__{}
     |> starting_at(:erlang.system_time(:seconds))
     |> with_ttl(3600)
     |> with_account_sid(Config.account_sid)
@@ -69,11 +68,11 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.allow_client_incoming("tommy")
   """
-  @spec allow_client_incoming(String.t) :: capability
+  @spec allow_client_incoming(String.t) :: t
   def allow_client_incoming(client_name), do: allow_client_incoming(new, client_name)
 
-  @spec allow_client_incoming(capability, String.t) :: capability
-  def allow_client_incoming(capability_struct = %Capability{incoming_client_names: client_names}, client_name) do
+  @spec allow_client_incoming(t, String.t) :: t
+  def allow_client_incoming(capability_struct = %__MODULE__{incoming_client_names: client_names}, client_name) do
     %{
       capability_struct |
       incoming_client_names: client_names ++ [client_name]
@@ -95,11 +94,11 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.allow_client_outgoing("APabe7650f654fc34655fc81ae71caa3ff")
   """
-  @spec allow_client_outgoing(String.t) :: capability
+  @spec allow_client_outgoing(String.t) :: t
   def allow_client_outgoing(app_sid), do: allow_client_outgoing(new, app_sid)
 
-  @spec allow_client_outgoing(capability, String.t) :: capability
-  def allow_client_outgoing(capability_struct = %Capability{}, app_sid) do
+  @spec allow_client_outgoing(t, String.t) :: t
+  def allow_client_outgoing(capability_struct = %__MODULE__{}, app_sid) do
     %{capability_struct | outgoing_client_app_sid: app_sid}
   end
 
@@ -112,8 +111,8 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.starting_at(1464096368)
   """
-  @spec starting_at(capability, non_neg_integer) :: capability
-  def starting_at(capability_struct = %Capability{}, start_time) do
+  @spec starting_at(t, non_neg_integer) :: t
+  def starting_at(capability_struct = %__MODULE__{}, start_time) do
     %{capability_struct | start_time: start_time}
   end
 
@@ -126,8 +125,8 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.with_account_sid('XXX')
   """
-  @spec with_account_sid(capability, String.t) :: capability
-  def with_account_sid(capability_struct = %Capability{}, account_sid) do
+  @spec with_account_sid(t, String.t) :: t
+  def with_account_sid(capability_struct = %__MODULE__{}, account_sid) do
     %{capability_struct | account_sid: account_sid}
   end
 
@@ -140,8 +139,8 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.with_auth_token('XXX')
   """
-  @spec with_auth_token(capability, String.t) :: capability
-  def with_auth_token(capability_struct = %Capability{}, auth_token) do
+  @spec with_auth_token(t, String.t) :: t
+  def with_auth_token(capability_struct = %__MODULE__{}, auth_token) do
     %{capability_struct | auth_token: auth_token}
   end
 
@@ -157,8 +156,8 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.with_ttl(3600)
   """
-  @spec with_ttl(capability, non_neg_integer) :: capability
-  def with_ttl(capability_struct = %Capability{}, ttl) do
+  @spec with_ttl(t, non_neg_integer) :: t
+  def with_ttl(capability_struct = %__MODULE__{}, ttl) do
     %{capability_struct | ttl: ttl}
   end
 
@@ -176,8 +175,8 @@ defmodule ExTwilio.Capability do
 
       ExTwilio.Capability.token
   """
-  @spec token(capability) :: String.t
-  def token(capability_struct = %Capability{
+  @spec token(t) :: String.t
+  def token(capability_struct = %__MODULE__{
     account_sid: account_sid,
     start_time: start_time,
     ttl: ttl,
@@ -189,20 +188,20 @@ defmodule ExTwilio.Capability do
     |> generate_jwt(auth_token)
   end
 
-  defp capabilities(capability_struct = %Capability{}) do
+  defp capabilities(capability_struct = %__MODULE__{}) do
     incoming_capabililities(capability_struct) ++
     outgoing_capabilities(capability_struct)
   end
 
-  defp outgoing_capabilities(%Capability{outgoing_client_app_sid: nil}) do
+  defp outgoing_capabilities(%__MODULE__{outgoing_client_app_sid: nil}) do
     []
   end
 
-  defp outgoing_capabilities(%Capability{outgoing_client_app_sid: app_sid}) do
+  defp outgoing_capabilities(%__MODULE__{outgoing_client_app_sid: app_sid}) do
     ["scope:client:outgoing?appSid=#{URI.encode(app_sid)}"]
   end
 
-  defp incoming_capabililities(%Capability{incoming_client_names: client_names}) do
+  defp incoming_capabililities(%__MODULE__{incoming_client_names: client_names}) do
     Enum.map(client_names, &incoming_capability(&1))
   end
 

--- a/test/ex_twilio/capability_test.exs
+++ b/test/ex_twilio/capability_test.exs
@@ -27,9 +27,10 @@ defmodule ExTwilio.CapabilityTest do
   end
 
   test ".allow_client_incoming appends additional client names" do
-    capability = %ExTwilio.Capability{}
-    |> ExTwilio.Capability.allow_client_incoming("tommy")
-    |> ExTwilio.Capability.allow_client_incoming("billy")
+    capability =
+      %ExTwilio.Capability{}
+      |> ExTwilio.Capability.allow_client_incoming("tommy")
+      |> ExTwilio.Capability.allow_client_incoming("billy")
 
     assert capability.incoming_client_names == ["tommy", "billy"]
   end
@@ -40,9 +41,10 @@ defmodule ExTwilio.CapabilityTest do
   end
 
   test ".allow_client_outgoing overwrites the previous app sid" do
-    capability = %ExTwilio.Capability{}
-    |> ExTwilio.Capability.allow_client_outgoing("app_sid")
-    |> ExTwilio.Capability.allow_client_outgoing("not_app_sid")
+    capability =
+      %ExTwilio.Capability{}
+      |> ExTwilio.Capability.allow_client_outgoing("app_sid")
+      |> ExTwilio.Capability.allow_client_outgoing("not_app_sid")
 
     assert capability.outgoing_client_app_sid == "not_app_sid"
   end
@@ -85,9 +87,10 @@ defmodule ExTwilio.CapabilityTest do
   end
 
   test ".token sets the incoming scope" do
-    capability = ExTwilio.Capability.new
-    |> ExTwilio.Capability.allow_client_incoming("tom my")
-    |> ExTwilio.Capability.allow_client_incoming("bil ly")
+    capability =
+      ExTwilio.Capability.new
+      |> ExTwilio.Capability.allow_client_incoming("tom my")
+      |> ExTwilio.Capability.allow_client_incoming("bil ly")
 
     assert decoded_token(capability).claims["scope"] == "scope:client:incoming?clientName=tom%20my scope:client:incoming?clientName=bil%20ly"
   end

--- a/test/ex_twilio/capability_test.exs
+++ b/test/ex_twilio/capability_test.exs
@@ -80,8 +80,9 @@ defmodule ExTwilio.CapabilityTest do
   end
 
   test ".token sets the outgoing scope" do
-    capability = ExTwilio.Capability.new
-    |> ExTwilio.Capability.allow_client_outgoing("app sid")
+    capability =
+      ExTwilio.Capability.new
+      |> ExTwilio.Capability.allow_client_outgoing("app sid")
 
     assert decoded_token(capability).claims["scope"] == "scope:client:outgoing?appSid=app%20sid"
   end


### PR DESCRIPTION
Hi @danielberkompas - I've implemented the instructions for receiving a call with Twilio that I'd previously left as `Pending...` in [CALLING_TUTORIAL.md](https://github.com/danielberkompas/ex_twilio/blob/master/CALLING_TUTORIAL.md).

Also, I did some minor refactoring to the `Capability` module as suggested by @pdawczak