### PR TITLE
Handle query string encoding of list values for the param map.

### DIFF
--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -83,7 +83,10 @@ defmodule ExTwilio.UrlGenerator do
   @spec to_query_string(list) :: String.t
   def to_query_string(list) do
     list
-    |> Enum.map(fn {key, value} -> {camelize(key), value} end)
+    |> Enum.flat_map(fn
+      {key, value} when is_list(value) -> Enum.map(value, &({camelize(key), &1}))
+      {key, value} -> [{camelize(key), value}]
+    end)
     |> URI.encode_query
   end
 

--- a/test/ex_twilio/url_generator_test.exs
+++ b/test/ex_twilio/url_generator_test.exs
@@ -11,12 +11,11 @@ defmodule ExTwilio.UrlGeneratorTest do
     def children, do: [:iso_country_code, :type]
   end
 
-  test "to_query_string does not strip out multiple params" do
+  test "to_query_string can handle a value of type list without error" do
     params = [
-      {"StatusCallback", "http://example.com/status_callback"},
-      {"StatusCallbackEvent", "ringing"},
-      {"StatusCallbackEvent", "answered"},
-      {"StatusCallbackEvent", "completed"}]
+      status_callback: "http://example.com/status_callback",
+      status_callback_event: ["ringing", "answered", "completed"]
+    ]
 
     assert ExTwilio.UrlGenerator.to_query_string(params) == "StatusCallback=http%3A%2F%2Fexample.com%2Fstatus_callback&StatusCallbackEvent=ringing&StatusCallbackEvent=answered&StatusCallbackEvent=completed"
   end


### PR DESCRIPTION
**The situation**

I would like to be notified by Twilio as an in-flight call I created progresses through various states. Using the current ExTwilio API, I would write:

```elixir
ExTwilio.Call.create(%{
  to: ..., 
  from: ..., 
  application_sid: ..., 
  status_callback_event: ["ringing", "answered", "completed"]
})
```

**The problem**

The creation attempt above throws an error:
```elixir
(ArgumentError) encode_query/1 values cannot be lists
```

**The culprit**
`ExTwilio.UrlGenerator.to_query_string` wraps a call to `URI.encode_query` which [forbids lists](https://hexdocs.pm/elixir/URI.html#encode_query/1) from being elements of the enumerable that we pass in.

The reasons why `URI.encode_query` forbids lists is essentially due to the lack of standards around encoding nested parameters in a URL. ([source](https://stackoverflow.com/a/41828334))

**The solution**

Thankfully, Twilio tells us exactly how we should encode our parameters.

<img width="636" alt="screen shot 2017-08-18 at 11 05 34 am" src="https://user-images.githubusercontent.com/19544466/29464922-6f97e640-8405-11e7-97ad-bb93ae8e2fd8.png">

Thus, we can edit how we map over our keyword list in `ExTwilio.UrlGenerator.to_query_string` before we ship it to `URI.encode_query`, ensuring that nested list elements are transformed in the same fashion as the top level elements. This allows us to encode the map above without error.

In addition, the original test needed to be updated. The data structure the test passed in to `ExTwilio.UrlGenerator.to_query_string` did not match the data structure that was actually being passed in the code.