### PR TITLE
Remove someone's hardcoded workspace sid from the url_builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 erl_crash.dump
 *.ez
 .env
+.DS_Store
 doc/

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -135,7 +135,7 @@ defmodule ExTwilio.UrlGenerator do
 
   @spec add_workspace_to_options(atom, list) :: list
   defp add_workspace_to_options(_module, options) do
-    Keyword.put_new(options, :workspace, "WS5129855a41766bf529b76052885f3ce0")
+    Keyword.put_new(options, :workspace, Config.workspace_sid)
   end
 
   @spec build_query(atom, list) :: String.t


### PR DESCRIPTION
Ran across this while working on another PR.  Looks like when TaskRouter was added this was left in rather than using the new config method.

I also added ```.DS_Store``` to the ```.gitignore``` to make things easier for osx-based contributors in the future.