### PR TITLE
Add all endpoints for the programmable chat api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ Twilio's TaskRouter API:
 - [Workspaces](https://www.twilio.com/docs/api/taskrouter/workspaces)
     - [Statistics](https://www.twilio.com/docs/api/taskrouter/workspace-statistics)
 
+Twilio's ProgrammableChat API:
+
+- [Overview](https://www.twilio.com/docs/api/chat/rest)
+- [Services](https://www.twilio.com/docs/api/chat/rest/services)
+  - [Channels](https://www.twilio.com/docs/api/chat/rest/channels)
+    - [Members](https://www.twilio.com/docs/api/chat/rest/members)
+  - [Users](https://www.twilio.com/docs/api/chat/rest/users)
+    - [UserChannels](https://www.twilio.com/docs/api/chat/rest/user-channels)
+  - [Roles](https://www.twilio.com/docs/api/chat/rest/user-channels)
+- [Credentials](https://www.twilio.com/docs/api/chat/rest/credentials)
+
 Twilio Capability Tokens:
 - [Worker](https://www.twilio.com/docs/api/taskrouter/worker-js)
 - [Calling](https://www.twilio.com/docs/api/client/capability-tokens)

--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -65,6 +65,7 @@ defmodule ExTwilio.Api do
   @spec create(atom, data, list) :: Parser.success | Parser.error
   def create(module, data, options \\ []) do
     data = format_data(data)
+
     module
     |> Url.build_url(nil, options)
     |> Api.post!(data, auth_header(options))

--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -47,6 +47,8 @@ defmodule ExTwilio.Config do
 
   def task_router_websocket_base_url(), do: "https://event-bridge.twilio.com/v1/wschannels"
 
+  def programmable_chat_url(), do: "https://chat.twilio.com/v2"
+
   @doc """
   A light wrapper around `Application.get_env/2`, providing automatic support for
   `{:system, "VAR"}` tuples.

--- a/lib/ex_twilio/parent.ex
+++ b/lib/ex_twilio/parent.ex
@@ -1,0 +1,10 @@
+defmodule ExTwilio.Parent do
+  @moduledoc """
+  This module provides structure for the specification of parents to a resource. It contains
+  a `module` which should be the full module name of the parent resource, as well as a key
+  which represents the key that will be matched against the options list to find the `sid` of the
+  parent resource and place it into the url correctly.
+  """
+  defstruct module: nil,
+            key: nil
+end

--- a/lib/ex_twilio/resource.ex
+++ b/lib/ex_twilio/resource.ex
@@ -78,7 +78,7 @@ defmodule ExTwilio.Resource do
       Delegates the real work to `ExTwilio.Api.resource_collection_name/1` by
       default.
 
-      Override in your module before `use ExTwilio.Resource` if you need
+      Override in your module after `use ExTwilio.Resource` if you need
       something different.
       """
       def resource_collection_name, do: Url.resource_collection_name(__MODULE__)
@@ -87,14 +87,31 @@ defmodule ExTwilio.Resource do
       CamelCase resource name as it would be used in Twilio's API. Delegates
       the real work to `ExTwilio.Api.resource_name/1` by default.
 
-      Override in your module before `use ExTwilio.Resource` if you need
+      Override in your module after `use ExTwilio.Resource` if you need
       something different.
       """
       def resource_name, do: Url.resource_name(__MODULE__)
 
+      @doc """
+      Parents represent path segments that precede the current resource. For example,
+      in the path `/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users` "Services" is
+      a parent.  Parents will always have a key in the next segment.  If your parent is under a
+      submodule of `ExTwilio`, specify your parent using the `ExTwilio.Parent` struct.
+
+      Override this method in your resource to specify parents in the order that they will appear
+      in the path.
+      """
       @spec parents :: list
       def parents, do: []
 
+      @doc """
+      Children represent path segments that come after the current resource. For example,
+      in the path `/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users/Active` "Active" is
+      a child.  Children may or may not have a key in the next segment.
+
+      Override this method in your resource to specify children in the order that they will appear
+      in the path.
+      """
       @spec children :: list
       def children, do: []
 

--- a/lib/ex_twilio/resources/member.ex
+++ b/lib/ex_twilio/resources/member.ex
@@ -21,3 +21,4 @@ defmodule ExTwilio.Member do
 
   def parents, do: [:account, :queue]
 end
+

--- a/lib/ex_twilio/resources/programmable_chat/channel.ex
+++ b/lib/ex_twilio/resources/programmable_chat/channel.ex
@@ -1,0 +1,32 @@
+defmodule ExTwilio.ProgrammableChat.Channel do
+  @moduledoc """
+  Represents a Channel resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/channels)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            unique_name: nil,
+            friendly_name: nil,
+            attributes: nil,
+            type: nil,
+            date_created: nil,
+            date_updated: nil,
+            created_by: nil,
+            members_count: nil,
+            messages_count: nil,
+            url: nil,
+            links: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service}]
+end

--- a/lib/ex_twilio/resources/programmable_chat/credential.ex
+++ b/lib/ex_twilio/resources/programmable_chat/credential.ex
@@ -1,0 +1,25 @@
+defmodule ExTwilio.ProgrammableChat.Credential do
+  @moduledoc """
+  Represents a Credential resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/credentials)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            friendly_name: nil,
+            type: nil,
+            sandbox: nil,
+            date_created: nil,
+            date_updated: nil,
+            url: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+end

--- a/lib/ex_twilio/resources/programmable_chat/member.ex
+++ b/lib/ex_twilio/resources/programmable_chat/member.ex
@@ -1,0 +1,33 @@
+defmodule ExTwilio.ProgrammableChat.Member do
+  @moduledoc """
+  Represents a Member resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/members)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            channel_sid: nil,
+            identity: nil,
+            role_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            last_consumed_message_index: nil,
+            last_consumption_timestamp: nil,
+            url: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service},
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Channel, key: :channel}
+  ]
+end

--- a/lib/ex_twilio/resources/programmable_chat/message.ex
+++ b/lib/ex_twilio/resources/programmable_chat/message.ex
@@ -1,0 +1,34 @@
+defmodule ExTwilio.ProgrammableChat.Message do
+  @moduledoc """
+  Represents a Message resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/messages)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            to: nil,
+            from: nil,
+            date_created: nil,
+            date_updated: nil,
+            was_edited: nil,
+            body: nil,
+            attributes: nil,
+            index: nil,
+            url: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service},
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Channel, key: :channel}
+  ]
+end

--- a/lib/ex_twilio/resources/programmable_chat/role.ex
+++ b/lib/ex_twilio/resources/programmable_chat/role.ex
@@ -1,0 +1,28 @@
+defmodule ExTwilio.ProgrammableChat.Role do
+  @moduledoc """
+  Represents a Message resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/roles)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            friendly_name: nil,
+            type: nil,
+            permissions: nil,
+            date_created: nil,
+            date_updated: nil,
+            url: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service}]
+end

--- a/lib/ex_twilio/resources/programmable_chat/service.ex
+++ b/lib/ex_twilio/resources/programmable_chat/service.ex
@@ -1,0 +1,36 @@
+defmodule ExTwilio.ProgrammableChat.Service do
+  @moduledoc """
+  Represents a Service resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/services)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            friendly_name: nil,
+            date_created: nil,
+            date_updated: nil,
+            default_service_role_sid: nil,
+            default_channel_role_sid: nil,
+            default_channel_creator_role_sid: nil,
+            typing_indicator_timeout: nil,
+            read_status_enabled: nil,
+            consumption_report_interval: nil,
+            reachability_enabled: nil,
+            limits: nil,
+            pre_webhook_url: nil,
+            post_webhook_url: nil,
+            webhook_method: nil,
+            webhook_filters: nil,
+            notifications: nil,
+            url: nil,
+            links: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+end

--- a/lib/ex_twilio/resources/programmable_chat/user.ex
+++ b/lib/ex_twilio/resources/programmable_chat/user.ex
@@ -1,0 +1,32 @@
+defmodule ExTwilio.ProgrammableChat.User do
+  @moduledoc """
+  Represents a User resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/users)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            role_sid: nil,
+            identity: nil,
+            friendly_name: nil,
+            attributes: nil,
+            date_created: nil,
+            date_updated: nil,
+            is_online: nil,
+            is_notifiable: nil,
+            joined_channels_count: nil,
+            url: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all,
+    :find,
+    :create,
+    :update,
+    :destroy
+  ]
+
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service}]
+end

--- a/lib/ex_twilio/resources/programmable_chat/user_channel.ex
+++ b/lib/ex_twilio/resources/programmable_chat/user_channel.ex
@@ -1,0 +1,26 @@
+defmodule ExTwilio.ProgrammableChat.UserChannel do
+  @moduledoc """
+  Represents a User Channel resource in the Twilio Programmable Chat API.
+
+  - [Twilio docs](https://www.twilio.com/docs/api/chat/rest/user-channels)
+  """
+
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            unread_messages_count: nil,
+            last_consumed_message_index: nil,
+            channel: nil,
+            member: nil
+
+  use ExTwilio.Resource, import: [
+    :stream,
+    :all
+  ]
+
+  def resource_name, do: "Channels"
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.Service, key: :service},
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableChat.User, key: :user}
+  ]
+end

--- a/lib/ex_twilio/resources/task_router/activity.ex
+++ b/lib/ex_twilio/resources/task_router/activity.ex
@@ -17,5 +17,5 @@ defmodule ExTwilio.TaskRouter.Activity do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :delete]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
 end

--- a/lib/ex_twilio/resources/task_router/event.ex
+++ b/lib/ex_twilio/resources/task_router/event.ex
@@ -23,7 +23,7 @@ defmodule ExTwilio.TaskRouter.Event do
 
   use ExTwilio.Resource, import: [:stream, :all, :find]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
   def children, do: [:minutes, :start_date, :end_date, :event_type, :worker_sid,
                      :task_queue_sid, :workflow_sid, :task_sid, :reservation_sid]
 end

--- a/lib/ex_twilio/resources/task_router/reservation.ex
+++ b/lib/ex_twilio/resources/task_router/reservation.ex
@@ -21,6 +21,9 @@ defmodule ExTwilio.TaskRouter.Reservation do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :update]
 
-  def parents, do: [:workspace, :task]
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace},
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Task, key: :task}
+  ]
   def children, do: [:worker_sid, :reservation_status]
 end

--- a/lib/ex_twilio/resources/task_router/task.ex
+++ b/lib/ex_twilio/resources/task_router/task.ex
@@ -28,6 +28,6 @@ defmodule ExTwilio.TaskRouter.Task do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :delete]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
   def children, do: [:attributes]
 end

--- a/lib/ex_twilio/resources/task_router/task_queue.ex
+++ b/lib/ex_twilio/resources/task_router/task_queue.ex
@@ -23,6 +23,12 @@ defmodule ExTwilio.TaskRouter.TaskQueue do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :delete]
 
-  def parents, do: [:workspace]
-  def children, do: [:friendly_name, :evaluate_worker_attributes, :reservation_activity_sid, :assignment_activity_sid, :target_workers]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
+  def children, do: [
+    :friendly_name,
+    :evaluate_worker_attributes,
+    :reservation_activity_sid,
+    :assignment_activity_sid,
+    :target_workers
+  ]
 end

--- a/lib/ex_twilio/resources/task_router/task_queue_statistic.ex
+++ b/lib/ex_twilio/resources/task_router/task_queue_statistic.ex
@@ -13,6 +13,9 @@ defmodule ExTwilio.TaskRouter.TaskQueueStatistic do
 
   use ExTwilio.Resource, import: [:stream, :all]
 
-  def parents, do: [:workspace, :task_queues]
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace},
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.TaskQueue, key: :task_queues}
+  ]
   def children, do: [:minutes, :friendly_name, :start_date, :end_date]
 end

--- a/lib/ex_twilio/resources/task_router/worker.ex
+++ b/lib/ex_twilio/resources/task_router/worker.ex
@@ -21,7 +21,7 @@ defmodule ExTwilio.TaskRouter.Worker do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :delete]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
   def children do
     [
       :friendly_name,

--- a/lib/ex_twilio/resources/task_router/worker_statistic.ex
+++ b/lib/ex_twilio/resources/task_router/worker_statistic.ex
@@ -13,6 +13,9 @@ defmodule ExTwilio.TaskRouter.WorkerStatistic do
 
   use ExTwilio.Resource, import: [:stream, :all, :find]
 
-  def parents, do: [:workspace, :workers]
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace},
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Worker, key: :workers}
+  ]
   def children, do: [:minutes, :friendly_name, :start_date, :end_date, :task_queue_name, :task_queue_sid]
 end

--- a/lib/ex_twilio/resources/task_router/workflow.ex
+++ b/lib/ex_twilio/resources/task_router/workflow.ex
@@ -21,6 +21,6 @@ defmodule ExTwilio.TaskRouter.Workflow do
 
   use ExTwilio.Resource, import: [:stream, :all, :find, :create, :update, :delete]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
   def children, do: [:friendly_name, :configuration]
 end

--- a/lib/ex_twilio/resources/task_router/workflow_statistic.ex
+++ b/lib/ex_twilio/resources/task_router/workflow_statistic.ex
@@ -13,6 +13,9 @@ defmodule ExTwilio.TaskRouter.WorkflowStatistic do
 
   use ExTwilio.Resource, import: [:stream, :all]
 
-  def parents, do: [:workspace, :workflow]
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace},
+    %ExTwilio.Parent{module: ExTwilio.TaskRouter.Workflow, key: :workflow}
+  ]
   def children, do: [:minutes, :start_date, :end_date]
 end

--- a/lib/ex_twilio/resources/task_router/workspace_statistic.ex
+++ b/lib/ex_twilio/resources/task_router/workspace_statistic.ex
@@ -13,6 +13,6 @@ defmodule ExTwilio.TaskRouter.WorkspaceStatistic do
 
   use ExTwilio.Resource, import: [:stream, :all]
 
-  def parents, do: [:workspace]
+  def parents, do: [%ExTwilio.Parent{module: ExTwilio.TaskRouter.Workspace, key: :workspace}]
   def children, do: [:minutes, :start_date, :end_date]
 end

--- a/test/ex_twilio/url_generator_test.exs
+++ b/test/ex_twilio/url_generator_test.exs
@@ -11,13 +11,50 @@ defmodule ExTwilio.UrlGeneratorTest do
     def children, do: [:iso_country_code, :type]
   end
 
-  test "to_query_string can handle a value of type list without error" do
-    params = [
-      status_callback: "http://example.com/status_callback",
-      status_callback_event: ["ringing", "answered", "completed"]
-    ]
+  defmodule Submodule.Parent do
+    defstruct sid: nil, name: nil
+    def resource_name, do: "Parents"
+    def resource_collection_name, do: "parents"
+    def parents, do: [:account]
+    def children, do: [:child]
+  end
 
-    assert ExTwilio.UrlGenerator.to_query_string(params) == "StatusCallback=http%3A%2F%2Fexample.com%2Fstatus_callback&StatusCallbackEvent=ringing&StatusCallbackEvent=answered&StatusCallbackEvent=completed"
+  defmodule Submodule.Child do
+    defstruct sid: nil, name: nil
+    def resource_name, do: "Children"
+    def resource_collection_name, do: "children"
+    def parents, do: [:account, %ExTwilio.Parent{module: Submodule.Parent, key: :parent}]
+    def children, do: []
+  end
+
+  describe "query strings" do
+    test "to_query_string can handle a value of type list without error" do
+      params = [
+        status_callback: "http://example.com/status_callback",
+        status_callback_event: ["ringing", "answered", "completed"]
+      ]
+
+      assert ExTwilio.UrlGenerator.to_query_string(params) == "StatusCallback=http%3A%2F%2Fexample.com%2Fstatus_callback&StatusCallbackEvent=ringing&StatusCallbackEvent=answered&StatusCallbackEvent=completed"
+    end
+
+    test "ignores parent keys at the root module level" do
+      options = [account: "1234"]
+      refute ExTwilio.UrlGenerator.build_url(Submodule.Child, nil, options) =~ "Account=1234"
+    end
+
+
+    test "ignores parent keys when parent in submodule" do
+      options = [parent: "1234"]
+      refute ExTwilio.UrlGenerator.build_url(Submodule.Child, nil, options) =~ "Parent=1234"
+    end
+  end
+
+  describe "building urls for modules with parent in submodule" do
+    test "builds a correct url for parent in a submodule" do
+      options = [account: 43, parent: 4551]
+      assert ExTwilio.UrlGenerator.build_url(Submodule.Child, nil, options) ==
+        "https://api.twilio.com/2010-04-01/Accounts/43/Parents/4551/Children.json"
+    end
   end
 
   doctest ExTwilio.UrlGenerator


### PR DESCRIPTION
# Primary changes
- Added the [Programmable Chat API](https://www.twilio.com/docs/api/chat/rest)
- Minor additions and corrections to existing documentation

# Internal Changes
I ran into an issue where `infer_module/1` couldn't be trusted to choose the correct module as submodules under `ExTwilio` are added.  I played with a few options before settling on the strategy of defining a `ExTwilio.Parent` struct and supplying parents in that format for any resources under a submodule.  This makes sure that we are always guaranteed to use the correct module to determine the resource name at the expense of some slightly less pretty but more explicit parent definitions.  The `UrlGenerator` deals with all parents consistently regardless of how they were specified so the original resources can maintain their format.

Please let me know if you'd prefer a different strategy but this was what felt best to me in terms of maintaining how the package works and providing correctness.

# Left to do
- [x] Squash commits