### PR TITLE
Config does not need system

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ You will need to set the following configuration variables in your
 ```elixir
 use Mix.Config
 
-config :ex_twilio, account_sid:   {:system, "TWILIO_ACCOUNT_SID"},
-                   auth_token:    {:system, "TWILIO_AUTH_TOKEN"},
-                   workspace_sid: {:system, "TWILIO_WORKSPACE_SID"} # optional
+config :ex_twilio, account_sid:   "TWILIO_ACCOUNT_SID",
+                   auth_token:    "TWILIO_AUTH_TOKEN",
+                   workspace_sid: "TWILIO_WORKSPACE_SID" # optional
 ```
 
 For security, I recommend that you use environment variables rather than hard


### PR DESCRIPTION
Previous version of example does not work.

Resulted in:
{:error, "The requested resource /2010-04-01/Messages.json was not found", 404}