### PR TITLE
Remove puts that could not be muted

### DIFF
--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -57,7 +57,6 @@ defmodule ExTwilio.UrlGenerator do
           url = add_segments(Config.base_url(), module, id, options) <> ".json"
           {url, options}
       end
-      IO.puts ">> Built url: #{url}"
     # Append querystring
     if Keyword.has_key?(options, :query) do
       url <> options[:query]


### PR DESCRIPTION
After integrating ex_twilio into our app we noticed a bunch of console
output during test runs, it was because of this line.