### PR TITLE
fix next_page_url generation & run mix format

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -23,6 +23,7 @@ defmodule ExTwilio.RequestValidator do
   end
 
   defp data_for(url, params), do: url <> combine(params)
+
   defp combine(params) do
     params
     |> Map.keys()

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -50,9 +50,6 @@ defmodule ExTwilio.ResultStream do
 
   defp process_page({next_page_uri, module, options}) do
     next_page_uri
-    |> next_page_url
     |> fetch_page(module, options)
   end
-
-  defp next_page_url(uri), do: "https://#{Config.api_domain()}" <> uri
 end

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -49,7 +49,6 @@ defmodule ExTwilio.ResultStream do
   defp process_page({nil, _module, _options}), do: {:halt, nil}
 
   defp process_page({next_page_uri, module, options}) do
-    next_page_uri
-    |> fetch_page(module, options)
+    fetch_page(next_page_uri, module, options)
   end
 end

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -40,7 +40,7 @@ defmodule ExTwilio.ResultStream do
   defp fetch_page(url, module, options) do
     results = Api.get!(url, Api.auth_header(options))
     {:ok, items, meta} = Parser.parse_list(results, module, module.resource_collection_name)
-    {items, {meta["next_page_uri"], module, options}}
+    {items, {next_page_url(meta["next_page_uri"]), module, options}}
   end
 
   @spec process_page({url | nil, module, options :: list}) ::
@@ -51,4 +51,6 @@ defmodule ExTwilio.ResultStream do
   defp process_page({next_page_uri, module, options}) do
     fetch_page(next_page_uri, module, options)
   end
+
+  defp next_page_url(uri), do: "https://#{Config.api_domain()}" <> uri
 end

--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -52,5 +52,6 @@ defmodule ExTwilio.ResultStream do
     fetch_page(next_page_uri, module, options)
   end
 
+  defp next_page_url(nil), do: nil
   defp next_page_url(uri), do: "https://#{Config.api_domain()}" <> uri
 end

--- a/test/ex_twilio/request_validator_test.exs
+++ b/test/ex_twilio/request_validator_test.exs
@@ -34,12 +34,13 @@ defmodule ExTwilio.RequestValidatorTest do
         "ApplicationSid" => "AP44efecad51364e80b133bb7c07eb8204"
       }
 
-      {:ok, [
-        params: params,
-        signature: "oVb2kXoVy8GEfwBDjR8bk/ZZ6eA=",
-        token: "2bd9e9638872de601313dc77410d3b23",
-        url: "http://twiliotests.heroku.com/validate/voice"
-      ]}
+      {:ok,
+       [
+         params: params,
+         signature: "oVb2kXoVy8GEfwBDjR8bk/ZZ6eA=",
+         token: "2bd9e9638872de601313dc77410d3b23",
+         url: "http://twiliotests.heroku.com/validate/voice"
+       ]}
     end
 
     test "validating a correct voice request", context do
@@ -83,15 +84,16 @@ defmodule ExTwilio.RequestValidatorTest do
         "ToZip" => "94105",
         "ToCountry" => "US",
         "ApiVersion" => "2010-04-01",
-        "SmsSid" => "SM2003cbd5e6a3701999aa3e5f20ff2787",
+        "SmsSid" => "SM2003cbd5e6a3701999aa3e5f20ff2787"
       }
 
-      {:ok, [
-        params: params,
-        signature: "mxeiv65lEe0b8L6LdVw2jgJi8yw=",
-        token: "2bd9e9638872de601313dc77410d3b23",
-        url: "http://twiliotests.heroku.com/validate/sms"
-      ]}
+      {:ok,
+       [
+         params: params,
+         signature: "mxeiv65lEe0b8L6LdVw2jgJi8yw=",
+         token: "2bd9e9638872de601313dc77410d3b23",
+         url: "http://twiliotests.heroku.com/validate/sms"
+       ]}
     end
 
     test "validating a correct sms request", context do


### PR DESCRIPTION
The URL builder initially has full url and when called with next_page_url(), it was generating something like this: `https://api.twilio.comhttps://api.twilio.com/....`

I think it makes sense to use `next_page_url/1` with `meta["next_page_uri"]`

If merged, this closes #88 

Also ran mix format on failing files on travis ci