### PR TITLE
add messaging_service_sid to the message resource

### DIFF
--- a/lib/ex_twilio/resources/message.ex
+++ b/lib/ex_twilio/resources/message.ex
@@ -23,7 +23,8 @@ defmodule ExTwilio.Message do
             price_unit: nil,
             api_version: nil,
             uri: nil,
-            subresource_uri: nil
+            subresource_uri: nil,
+            messaging_service_sid: nil
 
   use ExTwilio.Resource,
     import: [


### PR DESCRIPTION
Updates the `ExTwilio.Message` struct with the `messaging_service_sid` field to allow retrieving this from the API response.

I was looking for somewhere to update/add a test for this change, however I couldn't see anywhere that this module is currently being tested directly. If I am missing something can you point me in the right direction please.