### PR TITLE
Parser: Return full error JSON

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -38,11 +38,11 @@ defmodule ExTwilio.Api do
       {:ok, %Call{ ... }}
 
   If the resource could not be loaded, `find/2` will return a 3-element tuple
-  in this format, `{:error, message, code}`. The `code` is the HTTP status code
+  in this format, `{:error, error_body, code}`. The `code` is the HTTP status code
   returned by the Twilio API, for example, 404.
 
       ExTwilio.Api.find(ExTwilio.Call, "nonexistent sid")
-      {:error, "The requested resource couldn't be found...", 404}
+      {:error, %{"message" => The requested resource couldn't be found..."}, 404}
   """
   @spec find(atom, String.t() | nil, list) :: Parser.success() | Parser.error()
   def find(module, sid, options \\ []) do
@@ -61,7 +61,7 @@ defmodule ExTwilio.Api do
       {:ok, %Call{ ... }}
 
       ExTwilio.Api.create(ExTwilio.Call, [])
-      {:error, "No 'To' number is specified", 400}
+      {:error, %{"message" => "No 'To' number is specified"}, 400}
   """
   @spec create(atom, data, list) :: Parser.success() | Parser.error()
   def create(module, data, options \\ []) do
@@ -82,7 +82,7 @@ defmodule ExTwilio.Api do
       {:ok, %Call{ status: "canceled" ... }}
 
       ExTwilio.Api.update(ExTwilio.Call, "nonexistent", [status: "complete"])
-      {:error, "The requested resource ... was not found", 404}
+      {:error, %{"message" => "The requested resource ... was not found"}, 404}
   """
   @spec update(atom, String.t(), data, list) :: Parser.success() | Parser.error()
   def update(module, sid, data, options \\ [])
@@ -110,7 +110,7 @@ defmodule ExTwilio.Api do
       :ok
 
       ExTwilio.Api.destroy(ExTwilio.Call, "nonexistent")
-      {:error, "The requested resource ... was not found", 404}
+      {:error, %{"message" => The requested resource ... was not found"}, 404}
   """
   @spec destroy(atom, String.t()) :: Parser.success_delete() | Parser.error()
   def destroy(module, sid, options \\ [])

--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -10,7 +10,7 @@ defmodule ExTwilio.Parser do
   @type success :: {:ok, map}
   @type success_list :: {:ok, [map], metadata}
   @type success_delete :: :ok
-  @type error :: {:error, String.t(), http_status_code}
+  @type error :: {:error, map, http_status_code}
 
   @type parsed_response :: success | error
   @type parsed_list_response :: success_list | error
@@ -104,7 +104,7 @@ defmodule ExTwilio.Parser do
 
       %{body: body, status_code: status} ->
         {:ok, json} = Poison.decode(body)
-        {:error, json["message"], status}
+        {:error, json, status}
     end
   end
 end

--- a/test/ex_twilio/api_test.exs
+++ b/test/ex_twilio/api_test.exs
@@ -28,7 +28,7 @@ defmodule ExTwilio.ApiTest do
     json = json_response(%{message: "Error message"}, 404)
 
     with_fixture(:get!, json, fn ->
-      assert {:error, "Error message", 404} == Api.find(Resource, "id")
+      assert {:error, %{"message" => "Error message"}, 404} == Api.find(Resource, "id")
     end)
   end
 
@@ -45,7 +45,7 @@ defmodule ExTwilio.ApiTest do
     json = json_response(%{message: "Resource couldn't be created."}, 500)
 
     with_fixture(:post!, json, fn ->
-      assert {:error, "Resource couldn't be created.", 500} ==
+      assert {:error, %{"message" => "Resource couldn't be created."}, 500} ==
                Api.create(Resource, field: "value")
     end)
   end
@@ -67,7 +67,7 @@ defmodule ExTwilio.ApiTest do
     json = json_response(%{message: "The requested resource could not be found."}, 404)
 
     with_fixture(:post!, json, fn ->
-      expected = {:error, "The requested resource could not be found.", 404}
+      expected = {:error, %{"message" => "The requested resource could not be found."}, 404}
       assert expected == Api.update(Resource, "nonexistent", name: "Hello, World!")
     end)
   end
@@ -83,7 +83,7 @@ defmodule ExTwilio.ApiTest do
     json = json_response(%{message: "not found"}, 404)
 
     with_fixture(:delete!, json, fn ->
-      assert {:error, "not found", 404} == Api.destroy(Resource, "id")
+      assert {:error, %{"message" => "not found"}, 404} == Api.destroy(Resource, "id")
     end)
   end
 

--- a/test/ex_twilio/parser_test.exs
+++ b/test/ex_twilio/parser_test.exs
@@ -15,7 +15,7 @@ defmodule ExTwilio.ParserTest do
 
   test ".parse should return an error when response is 400" do
     response = %{body: "{ \"message\": \"Error message\" }", status_code: 400}
-    assert {:error, "Error message", 400} == parse(response, Resource)
+    assert {:error, %{"message" => "Error message"}, 400} == parse(response, Resource)
   end
 
   test ".parse should return :ok when response is 204 'No Content'" do


### PR DESCRIPTION
It would be useful to return the full error JSON for failed requests since that payload includes the error code, which is typically an easier and more reliable value to work with programmatically than the human-readable error message.