### PR TITLE
Parser: Make JSON library configurable

### DIFF
--- a/lib/ex_twilio/parser.ex
+++ b/lib/ex_twilio/parser.ex
@@ -43,7 +43,7 @@ defmodule ExTwilio.Parser do
   @spec parse(HTTPoison.Response.t(), module) :: success | error
   def parse(response, module) do
     handle_errors(response, fn body ->
-      Poison.decode!(body, as: target(module))
+      json_library().decode!(body, as: target(module))
     end)
   end
 
@@ -84,7 +84,7 @@ defmodule ExTwilio.Parser do
     result =
       handle_errors(response, fn body ->
         as = Map.put(%{}, key, [target(module)])
-        Poison.decode!(body, as: as)
+        json_library().decode!(body, as: as)
       end)
 
     case result do
@@ -103,8 +103,12 @@ defmodule ExTwilio.Parser do
         :ok
 
       %{body: body, status_code: status} ->
-        {:ok, json} = Poison.decode(body)
+        json = json_library().decode!(body)
         {:error, json["message"], status}
     end
+  end
+
+  defp json_library do
+    Application.get_env(:ex_twilio, :json_library, Poison)
   end
 end


### PR DESCRIPTION
This makes the JSON library that Parser uses configurable to match the recent changes by Ecto and [Phoenix](https://github.com/phoenixframework/phoenix/commit/7be6a88d24e10ab6d028bf75e5b5e6509e61d8cb).