### PR TITLE
fixing wrong resource_collection_name in ExTwilio.Memeber resource

### DIFF
--- a/lib/ex_twilio/resources/member.ex
+++ b/lib/ex_twilio/resources/member.ex
@@ -20,4 +20,6 @@ defmodule ExTwilio.Member do
   use ExTwilio.Resource, import: [:stream, :all, :find, :update]
 
   def parents, do: [:account, :queue]
+
+  def resource_collection_name(), do: Url.resource_collection_name(ExTwilio.QueueMember)
 end

--- a/lib/ex_twilio/resources/member.ex
+++ b/lib/ex_twilio/resources/member.ex
@@ -21,5 +21,5 @@ defmodule ExTwilio.Member do
 
   def parents, do: [:account, :queue]
 
-  def resource_collection_name(), do: Url.resource_collection_name(ExTwilio.QueueMember)
+  def resource_collection_name, do: Url.resource_collection_name(ExTwilio.QueueMember)
 end


### PR DESCRIPTION
This PR is fix for #111 