### PR TITLE
Add Fax resource

### DIFF
--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -50,6 +50,8 @@ defmodule ExTwilio.Config do
   """
   def base_url, do: "#{protocol()}://#{api_domain()}/#{api_version()}"
 
+  def fax_url, do: "https://fax.twilio.com/v1"
+
   def task_router_url, do: "https://taskrouter.twilio.com/v1"
 
   def task_router_websocket_base_url, do: "https://event-bridge.twilio.com/v1/wschannels"

--- a/lib/ex_twilio/resources/fax.ex
+++ b/lib/ex_twilio/resources/fax.ex
@@ -1,5 +1,7 @@
 defmodule ExTwilio.Fax do
   @moduledoc """
+  Warning! currently in Public beta.
+
   Represents a Fax resource in the Twilio API.
 
   - [Twilio docs](https://www.twilio.com/docs/fax/api)

--- a/lib/ex_twilio/resources/fax.ex
+++ b/lib/ex_twilio/resources/fax.ex
@@ -1,0 +1,34 @@
+defmodule ExTwilio.Fax do
+  @moduledoc """
+  Represents a Fax resource in the Twilio API.
+
+  - [Twilio docs](https://www.twilio.com/docs/fax/api)
+
+  Here is an example of sending an SMS message:
+
+    ExTwilio.Fax.create(to: "+15558675310", from: "+15017122661", media_url: "https://www.twilio.com/docs/documents/25/justthefaxmaam.pdf")
+  """
+
+  defstruct sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            account_sid: nil,
+            from: nil,
+            to: nil,
+            num_pages: nil,
+            status: nil,
+            error_code: nil,
+            error_message: nil,
+            direction: nil,
+            price: nil,
+            price_unit: nil,
+            api_version: nil,
+            url: nil,
+            links: nil,
+            media_url: nil,
+            media_sid: nil,
+            quality: nil,
+            duration: nil
+
+  use ExTwilio.Resource, import: [:stream, :find, :create]
+end

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -55,6 +55,10 @@ defmodule ExTwilio.UrlGenerator do
           url = add_segments(Config.notify_url(), module, id, options)
           {url, options}
 
+        ["ExTwilio", "Fax" | _] ->
+          url = add_segments(Config.fax_url(), module, id, options)
+          {url, options}
+
         _ ->
           # Add Account SID segment if not already present
           options = add_account_to_options(module, options)


### PR DESCRIPTION
## Overview
Mostly straightforward, adding the faxing endpoint to `ex_twilio` according to their API docs here: https://www.twilio.com/docs/fax/quickstart

## Outstanding Questions/TODOs
- [ ] Testing? I don't see much testing for individual resources. Did I miss them somewhere?
- [x] See if Travis CI passes