### PR TITLE
Allow request options to be configured for HTTPoison/hackney Twilio requests

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -184,6 +184,10 @@ defmodule ExTwilio.Api do
     |> auth_header({Config.account_sid(), Config.auth_token()})
   end
 
+  def process_request_options(options) do
+    Keyword.merge(options, Config.request_options())
+  end
+
   @spec format_data(data) :: binary
   def format_data(data) when is_map(data) do
     data

--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -36,6 +36,11 @@ defmodule ExTwilio.Config do
   def protocol, do: Application.get_env(:ex_twilio, :protocol) || "https"
 
   @doc """
+  Options added to HTTPoison requests
+  """
+  def request_options, do: from_env(:ex_twilio, :request_options, [])
+
+  @doc """
   Returns the version of the API that ExTwilio is going to talk to. Set it in
   `mix.exs`:
       config :ex_twilio, api_version: "2015-05-06"

--- a/test/ex_twilio/api_test.exs
+++ b/test/ex_twilio/api_test.exs
@@ -88,7 +88,7 @@ defmodule ExTwilio.ApiTest do
   end
 
   ###
-  # HTTPotion API
+  # HTTPoison API
   ###
 
   test ".process_request_headers adds the correct headers" do
@@ -96,6 +96,16 @@ defmodule ExTwilio.ApiTest do
     content = {:"Content-Type", "application/x-www-form-urlencoded; charset=UTF-8"}
     assert content in headers
     assert Keyword.keys(headers) == [:Authorization, :"Content-Type"]
+  end
+
+  test ".process_request_options adds configured options if configured" do
+    assert Api.process_request_options([]) == []
+
+    Application.put_env(:ex_twilio, :request_options, hackney: [pool: :mavis])
+    assert Api.process_request_options([]) == [hackney: [pool: :mavis]]
+    assert Api.process_request_options(bob: :sue) == [bob: :sue, hackney: [pool: :mavis]]
+  after
+    Application.delete_env(:ex_twilio, :request_options)
   end
 
   test ".format_data converts data to a query string when passed a list" do


### PR DESCRIPTION
Enables Twilio requests, for instance, to use a specific (non-default) hackney connection pool giving finer control over the maximum number of concurrent requests allowed on a specific node.

This would be done with the configuration

```elixir
config :ex_twilio, :request_options, hackney: [pool: :twilio_pool]
```