### PR TITLE
Use crypto new API

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -32,7 +32,11 @@ defmodule ExTwilio.RequestValidator do
     |> Enum.join()
   end
 
-  defp compute_hmac(data, key), do: :crypto.hmac(:sha, key, data)
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp compute_hmac(data, key), do: :crypto.mac(:hmac, :sha, key, data)
+  else
+    defp compute_hmac(data, key), do: :crypto.hmac(:sha, key, data)
+  end
 
   # Implementation taken from Plug.Crypto
   # https://github.com/elixir-plug/plug/blob/master/lib/plug/crypto.ex


### PR DESCRIPTION
The old API [is deprecated in OTP 22](https://erlang.org/doc/general_info/deprecations.html#functions-deprecated-in-otp-22) and going to [be removed in OTP 24](https://erlang.org/doc/general_info/scheduled_for_removal.html#old-crypto-api)