### PR TITLE
Documentation Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ def deps do
 end
 ```
 
-and run `mix deps.get`. Now, list the `:ex_twilio` application as your application dependency:
+and run `mix deps.get`. 
+
+
+If using elixir 1.3 or lower add `:ex_twilio` as a application dependency:
 
 ```elixir
 def application do


### PR DESCRIPTION
When using elixir 1.3 or higher you will receive the following error when adding `ex_twilio` as application dependency.

```
** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```
I just modified the README
