### PR TITLE
Fix dialyzer errors

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -13,6 +13,8 @@ MIX_ENV=test mix format --check-formatted || { echo 'Please format code with `mi
 
 MIX_ENV=test mix compile --warnings-as-errors --force || { echo 'Please fix all compiler warnings.'; exit 1; }
 
+MIX_ENV=test mix dialyze || { echo 'Please fix all dialyzer errors.'; exit 1; }
+
 MIX_ENV=test mix docs  || { echo 'Elixir HTML docs were not generated!'; exit 1; }
 
 mix test || { echo 'Elixir tests failed!'; exit 1; }

--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -15,7 +15,6 @@ defmodule ExTwilio.Api do
   Items are returned as instances of the given module's struct. For more
   details, see the documentation for each function.
   """
-
   use HTTPoison.Base
 
   alias ExTwilio.Config
@@ -170,25 +169,9 @@ defmodule ExTwilio.Api do
 
   def auth_header(headers, _), do: headers
 
-  ###
-  # HTTPotion API
-  ###
+  @spec format_data(any) :: binary
+  def format_data(data)
 
-  @doc """
-  Automatically adds the correct headers to each API request.
-  """
-  @spec process_request_headers(list) :: list
-  def process_request_headers(headers \\ []) do
-    headers
-    |> Keyword.put(:"Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-    |> auth_header({Config.account_sid(), Config.auth_token()})
-  end
-
-  def process_request_options(options) do
-    Keyword.merge(options, Config.request_options())
-  end
-
-  @spec format_data(data) :: binary
   def format_data(data) when is_map(data) do
     data
     |> Map.to_list()
@@ -200,4 +183,18 @@ defmodule ExTwilio.Api do
   end
 
   def format_data(data), do: data
+
+  ###
+  # HTTPotion API
+  ###
+
+  def process_request_headers(headers \\ []) do
+    headers
+    |> Keyword.put(:"Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+    |> auth_header({Config.account_sid(), Config.auth_token()})
+  end
+
+  def process_request_options(options) do
+    Keyword.merge(options, Config.request_options())
+  end
 end

--- a/lib/ex_twilio/jwt/access_token.ex
+++ b/lib/ex_twilio/jwt/access_token.ex
@@ -95,7 +95,7 @@ defmodule ExTwilio.JWT.AccessToken do
         "cty" => "twilio-fpa;v=1"
       })
 
-    Joken.generate_and_sign!(token_config, nil, signer)
+    Joken.generate_and_sign!(token_config, %{}, signer)
   end
 
   defp list_of_grants?(grants) when is_list(grants) do

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -147,6 +147,8 @@ defmodule ExTwilio.UrlGenerator do
   end
 
   @spec add_account_to_options(atom, list) :: list
+  defp add_account_to_options(module, options)
+
   defp add_account_to_options(module, options) do
     if module == ExTwilio.Account and options[:account] == nil do
       options
@@ -155,7 +157,6 @@ defmodule ExTwilio.UrlGenerator do
     end
   end
 
-  @spec add_account_to_options(atom, list) :: list
   defp add_flow_to_options(_module, options) do
     Keyword.put_new(options, :flow, Keyword.get(options, :flow_sid))
   end


### PR DESCRIPTION
I'm now using this lib as a dependency on a private project and our dialyzer checks complained that a call to `ExTwilio.JWT.AccessToken.to_jwt!/1` would make the enclosing function have no local return. After some digging I've found the culprit - the success typing for `Joken.generate_and_sign!/3` requires that the second params is a map instead of `nil`.

That's one of the changes - I've also taken the opportunity to fix the remaining dialyzer errors on the project and added a new step to the Semaphore CI checks so we can ensure no more issues arise.