### PR TITLE
Use mac instead of hmac, as it was deprecated in otp 24

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -32,7 +32,11 @@ defmodule ExTwilio.RequestValidator do
     |> Enum.join()
   end
 
-  defp compute_hmac(data, key), do: :crypto.hmac(:sha, key, data)
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp compute_hmac(data, key), do: :crypto.mac(:hmac, :sha, key, data)
+  else
+    defp compute_hmac(data, key), do: :crypto.hmac(:sha, key, data)
+  end
 
   # Implementation taken from Plug.Crypto
   # https://github.com/elixir-plug/plug/blob/master/lib/plug/crypto.ex


### PR DESCRIPTION
OTP 24 deprecates :crypto.hmac/3.

Using the same fix implemented in plug crypto:
https://github.com/elixir-plug/plug_crypto/blob/master/lib/plug/crypto/message_verifier.ex#L98