### PR TITLE
fix(deprecation): :crypto.hmac -> :crypto.mac, Bitwise.^^^ -> Bitwise.bxor

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -32,7 +32,14 @@ defmodule ExTwilio.RequestValidator do
     |> Enum.join()
   end
 
-  defp compute_hmac(data, key), do: :crypto.hmac(:sha, key, data)
+  defp compute_hmac(data, key), do: hmac(:sha, key, data)
+
+  # TODO: remove when we require OTP 22
+  if System.otp_release() >= "22" do
+    defp hmac(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    defp hmac(digest, key, data), do: :crypto.hmac(digest, key, data)
+  end
 
   # Implementation taken from Plug.Crypto
   # https://github.com/elixir-plug/plug/blob/master/lib/plug/crypto.ex
@@ -48,7 +55,7 @@ defmodule ExTwilio.RequestValidator do
   end
 
   defp secure_compare(<<x, left::binary>>, <<y, right::binary>>, acc) do
-    xorred = x ^^^ y
+    xorred = bxor(x, y)
     secure_compare(left, right, acc ||| xorred)
   end
 


### PR DESCRIPTION
Related to PR https://github.com/danielberkompas/ex_twilio/pull/147#issue-581644554 to support OTP 24

- fixes deprecation for `:cryto.hmac/3` with backward compatibility prior to OTP 22
- fixes deprecation warning for Bitwise.^^^ usage