### PR TITLE
Add Programmable Messaging APIs

### DIFF
--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -69,6 +69,8 @@ defmodule ExTwilio.Config do
 
   def video_url, do: "https://video.twilio.com/v1"
 
+  def programmable_messaging_url, do: "https://messaging.twilio.com/v1"
+
   @doc """
   A light wrapper around `Application.get_env/2`, providing automatic support for
   `{:system, "VAR"}` tuples.

--- a/lib/ex_twilio/resources/programmable_messaging/alpha_sender.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/alpha_sender.ex
@@ -1,0 +1,29 @@
+defmodule ExTwilio.ProgrammableMessaging.AlphaSender do
+  @moduledoc """
+  Represents an AlphaSender resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/alphasender-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            alpha_sender: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/phone_number.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/phone_number.ex
@@ -1,0 +1,30 @@
+defmodule ExTwilio.ProgrammableMessaging.PhoneNumber do
+  @moduledoc """
+  Represents a PhoneNumber resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/phonenumber-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            phone_number: nil,
+            country_code: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/service.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/service.ex
@@ -1,0 +1,38 @@
+defmodule ExTwilio.ProgrammableMessaging.Service do
+  @moduledoc """
+  Represents a Service resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            friendly_name: nil,
+            date_created: nil,
+            date_updated: nil,
+            inbound_request_url: nil,
+            inbound_method: nil,
+            fallback_url: nil,
+            fallback_method: nil,
+            status_callback: nil,
+            sticky_sender: nil,
+            mms_converter: nil,
+            smart_encoding: nil,
+            scan_message_content: nil,
+            fallback_to_long_code: nil,
+            area_code_geomatch: nil,
+            synchronous_validation: nil,
+            validity_period: nil,
+            url: nil,
+            links: nil,
+            use_inbound_webhook_on_number: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :update,
+      :destroy
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/short_code.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/short_code.ex
@@ -1,0 +1,30 @@
+defmodule ExTwilio.ProgrammableMessaging.ShortCode do
+  @moduledoc """
+  Represents a ShortCode resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/shortcode-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            short_code: nil,
+            country_code: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -68,6 +68,10 @@ defmodule ExTwilio.UrlGenerator do
           url = add_segments(Config.video_url(), module, id, options)
           {url, options}
 
+        ["ExTwilio", "ProgrammableMessaging" | _] ->
+          url = add_segments(Config.programmable_messaging_url(), module, id, options)
+          {url, options}
+
         _ ->
           # Add Account SID segment if not already present
           options = add_account_to_options(module, options)


### PR DESCRIPTION
Add missing APIs for Programmable Messaging:

- Messaging Services
- Phone Numbers
- Short Codes
- Alpha Senders

docs: https://www.twilio.com/docs/messaging