### PR TITLE
Configurable URLs

### DIFF
--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -55,19 +55,27 @@ defmodule ExTwilio.Config do
   """
   def base_url, do: "#{protocol()}://#{api_domain()}/#{api_version()}"
 
-  def fax_url, do: "https://fax.twilio.com/v1"
+  def fax_url, do: from_env(:fax_url, "#{protocol()}://fax.#{domain()}/v1")
 
-  def task_router_url, do: "https://taskrouter.twilio.com/v1"
+  def task_router_url, do: from_env(:task_router_url, "#{protocol()}://taskrouter.#{domain()}/v1")
 
-  def task_router_websocket_base_url, do: "https://event-bridge.twilio.com/v1/wschannels"
+  def task_router_websocket_base_url,
+    do:
+      from_env(
+        :task_router_websocket_base_url,
+        "#{protocol()}://event-bridge.#{domain()}/v1/wschannels"
+      )
 
-  def programmable_chat_url, do: "https://chat.twilio.com/v2"
+  def programmable_chat_url,
+    do: from_env(:programmable_chat_url, "#{protocol()}://chat.#{domain()}/v2")
 
-  def notify_url, do: "https://notify.twilio.com/v1"
+  def notify_url, do: from_env(:notify_url, "#{protocol()}://notify.#{domain()}/v1")
 
-  def studio_url, do: "https://studio.twilio.com/v1"
+  def studio_url, do: from_env(:studio_url, "#{protocol()}://studio.#{domain()}/v1")
 
-  def video_url, do: "https://video.twilio.com/v1"
+  def video_url, do: from_env(:video_url, "#{protocol()}://video.#{domain()}/v1")
+
+  defp domain, do: from_env(:domain, "twilio.com")
 
   defp from_env(key, default \\ nil)
 

--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -11,14 +11,14 @@ defmodule ExTwilio.Config do
 
       config :ex_twilio, account_sid: "YOUR_ACCOUNT_SID"
   """
-  def account_sid, do: from_env(:ex_twilio, :account_sid)
+  def account_sid, do: from_env(:account_sid)
 
   @doc """
   Returns the Twilio Auth Token for your account. Set it in `mix.exs`:
 
       config :ex_twilio, auth_token: "YOUR_AUTH_TOKEN"
   """
-  def auth_token, do: from_env(:ex_twilio, :auth_token)
+  def auth_token, do: from_env(:auth_token)
 
   @doc """
   Returns the domain of the Twilio API. This will default to "api.twilio.com",
@@ -26,7 +26,7 @@ defmodule ExTwilio.Config do
 
       config :ex_twilio, api_domain: "other.twilio.com"
   """
-  def api_domain, do: from_env(:ex_twilio, :api_domain, "api.twilio.com")
+  def api_domain, do: from_env(:api_domain, "api.twilio.com")
 
   @doc """
   Returns the protocol used for the Twilio API. The default is `"https"` for
@@ -38,7 +38,7 @@ defmodule ExTwilio.Config do
   @doc """
   Options added to HTTPoison requests
   """
-  def request_options, do: from_env(:ex_twilio, :request_options, [])
+  def request_options, do: from_env(:request_options, [])
 
   @doc """
   Returns the version of the API that ExTwilio is going to talk to. Set it in
@@ -69,14 +69,10 @@ defmodule ExTwilio.Config do
 
   def video_url, do: "https://video.twilio.com/v1"
 
-  @doc """
-  A light wrapper around `Application.get_env/2`, providing automatic support for
-  `{:system, "VAR"}` tuples.
-  """
-  def from_env(otp_app, key, default \\ nil)
+  defp from_env(key, default \\ nil)
 
-  def from_env(otp_app, key, default) do
-    otp_app
+  defp from_env(key, default) do
+    :ex_twilio
     |> Application.get_env(key, default)
     |> read_from_system(default)
   end

--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -47,7 +47,7 @@ defmodule ExTwilio.Config do
   """
   def api_version, do: Application.get_env(:ex_twilio, :api_version) || "2010-04-01"
 
-  def workspace_sid, do: Application.get_env(:ex_twilio, :workspace_sid) || "12345"
+  def workspace_sid, do: from_env(:workspace_sid, "12345")
 
   @doc """
   Return the combined base URL of the Twilio API, using the configuration

--- a/test/ex_twilio/config_test.exs
+++ b/test/ex_twilio/config_test.exs
@@ -1,0 +1,155 @@
+defmodule ExTwilio.ConfigTest do
+  use ExUnit.Case
+
+  alias ExTwilio.Config
+
+  describe "account_sid/0" do
+    test "required config" do
+      value = System.get_env("TWILIO_TEST_ACCOUNT_SID")
+      assert Config.account_sid() == value
+    end
+  end
+
+  describe "auth_token/0" do
+    test "required config" do
+      value = System.get_env("TWILIO_TEST_AUTH_TOKEN")
+      assert Config.auth_token() == value
+    end
+  end
+
+  describe "workspace_id/0" do
+    test "provided config" do
+      value = System.get_env("TWILIO_TEST_WORKSPACE_SID")
+      assert Config.workspace_sid() == value
+    end
+
+    test "default config" do
+      clean_env(:workspace_sid)
+      assert Config.workspace_sid() == "12345"
+      put_env(:workspace_sid, {:system, "TWILIO_TEST_WORKSPACE_SID"})
+    end
+  end
+
+  describe "api_domain/0" do
+    test "default config" do
+      assert Config.api_domain() == "api.twilio.com"
+    end
+
+    test "provided config" do
+      put_env(:api_domain, "some.other.domain")
+      assert Config.api_domain() == "some.other.domain"
+      clean_env(:api_domain)
+    end
+  end
+
+  describe "protocol/0" do
+    test "default config" do
+      assert Config.protocol() == "https"
+    end
+
+    test "provided config" do
+      put_env(:protocol, "fakeprotocol")
+      assert Config.protocol() == "fakeprotocol"
+      clean_env(:protocol)
+    end
+  end
+
+  describe "base_url/0" do
+    test "default config" do
+      assert Config.base_url() == "https://api.twilio.com/2010-04-01"
+    end
+  end
+
+  describe "fax_url/0" do
+    test "default config" do
+      assert Config.fax_url() == "https://fax.twilio.com/v1"
+    end
+
+    test "provided config" do
+      put_env(:fax_url, "another.fax.url")
+      assert Config.fax_url() == "another.fax.url"
+      clean_env(:fax_url)
+    end
+  end
+
+  describe "task_router_url/0" do
+    test "default config" do
+      assert Config.task_router_url() == "https://taskrouter.twilio.com/v1"
+    end
+
+    test "provided config" do
+      put_env(:task_router_url, "another.task.router.url")
+      assert Config.task_router_url() == "another.task.router.url"
+      clean_env(:task_router_url)
+    end
+  end
+
+  describe "task_router_websocket_base_url/0" do
+    test "default config" do
+      assert Config.task_router_websocket_base_url() ==
+               "https://event-bridge.twilio.com/v1/wschannels"
+    end
+
+    test "provided config" do
+      put_env(:task_router_websocket_base_url, "another.task.router.websocket.url")
+      assert Config.task_router_websocket_base_url() == "another.task.router.websocket.url"
+      clean_env(:task_router_websocket_base_url)
+    end
+  end
+
+  describe "programmable_chat_url/0" do
+    test "default config" do
+      assert Config.programmable_chat_url() == "https://chat.twilio.com/v2"
+    end
+
+    test "provided config" do
+      put_env(:programmable_chat_url, "another.chat.url")
+      assert Config.programmable_chat_url() == "another.chat.url"
+      clean_env(:programmable_chat_url)
+    end
+  end
+
+  describe "notify_url/0" do
+    test "default config" do
+      assert Config.notify_url() == "https://notify.twilio.com/v1"
+    end
+
+    test "provided config" do
+      put_env(:notify_url, "another.notify.url")
+      assert Config.notify_url() == "another.notify.url"
+      clean_env(:notify_url)
+    end
+  end
+
+  describe "sutdio_url/0" do
+    test "default config" do
+      assert Config.studio_url() == "https://studio.twilio.com/v1"
+    end
+
+    test "provided config" do
+      put_env(:studio_url, "another.studio.url")
+      assert Config.studio_url() == "another.studio.url"
+      clean_env(:studio_url)
+    end
+  end
+
+  describe "video_url/0" do
+    test "default config" do
+      assert Config.video_url() == "https://video.twilio.com/v1"
+    end
+
+    test "provided config" do
+      put_env(:video_url, "another.video.url")
+      assert Config.video_url() == "another.video.url"
+      clean_env(:video_url)
+    end
+  end
+
+  defp put_env(key, value) do
+    Application.put_env(:ex_twilio, key, value)
+  end
+
+  defp clean_env(key) do
+    Application.delete_env(:ex_twilio, key)
+  end
+end


### PR DESCRIPTION
this is a draft to check if the direction that I'm going is ok.
Next steps would be making every ExTwilio function that ends up on a request, configurable with options for api_key, account sid, workspace sid, etc.
I can do the configurable requests in a different PR change this one from draft to PR.