### PR TITLE
Support Twilio API key-based authentication

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -128,11 +128,14 @@ defmodule ExTwilio.Api do
   end
 
   @doc """
-  Builds custom auth header for subaccounts.
+  Builds custom auth header for subaccounts or API key-based auth.
 
   ## Examples
     iex> ExTwilio.Api.auth_header([account: 123, token: 123])
     ["Authorization": "Basic MTIzOjEyMw=="]
+
+    iex> ExTwilio.Api.auth_header([api_key: SK1, api_secret: 456])
+    ["Authorization": "Basic RWxpeGlyLlNLMTo0NTY="]
 
     iex> ExTwilio.Api.auth_header([], {nil, 2})
     []
@@ -140,7 +143,13 @@ defmodule ExTwilio.Api do
   """
   @spec auth_header(options :: list) :: list
   def auth_header(options \\ []) do
-    auth_header([], {options[:account], options[:token]})
+    case Keyword.has_key?(options, :api_key) and Keyword.has_key?(options, :api_secret) do
+      true ->
+        auth_header([], {options[:api_key], options[:api_secret]})
+
+      false ->
+        auth_header([], {options[:account], options[:token]})
+    end
   end
 
   @doc """

--- a/test/ex_twilio/api_test.exs
+++ b/test/ex_twilio/api_test.exs
@@ -87,6 +87,30 @@ defmodule ExTwilio.ApiTest do
     end)
   end
 
+  test ".auth_header returns no headers by default" do
+    assert [] == Api.auth_header([])
+  end
+
+  test ".auth_header with account and token options generates an account-level HTTP BASIC Authorization header" do
+    account = "AC-testsid"
+    token = "test-account-token"
+    encoded = Base.encode64("#{account}:#{token}")
+    basic_header = "Basic #{encoded}"
+    assert [Authorization: basic_header] == Api.auth_header([account: account, token: token])
+  end
+
+  test ".auth_header with api_key and api_secret options generates an API key-level HTTP BASIC Authorization header" do
+    api_key = "SK-testkey"
+    api_secret = "test-api-secret"
+    encoded = Base.encode64("#{api_key}:#{api_secret}")
+    basic_header = "Basic #{encoded}"
+    assert [Authorization: basic_header] == Api.auth_header([api_key: api_key, api_secret: api_secret])
+  end
+
+  test ".auth_header with an existing Authorization header retains the existing header" do
+    assert [Authorization: "BASIC existing"] == Api.auth_header([Authorization: "BASIC existing"], {"sid", "token"})
+  end
+
   ###
   # HTTPoison API
   ###


### PR DESCRIPTION
This PR adds support for API key auth as discussed in https://github.com/danielberkompas/ex_twilio/issues/124

With this change callers to APIs are able to pass `api_key` and `api_secret` options to the various REST API calls to use API key-based auth in place of the account token-based auth. This works by following the pattern of the optional `account`/`token` params already supported for sub-account auth.

I will admit I do not know Twilio's various APIs all that well or the internals of this library all that well. So my manual testing was limited to the `ExTwilio.Message.create` function which is the only place I happen to need this functionality.

When using API keys for auth you still need the account-level SID in your `ExTwilio` configuration but the account-level auth token can be omitted.

Also happy to do some other manual testing or revisit this approach, with a little guidance, if this PR seems way off the mark.