### PR TITLE
Import Bitwise module rather than using it

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -7,7 +7,7 @@ defmodule ExTwilio.RequestValidator do
 
   alias ExTwilio.Config
 
-  use Bitwise
+  import Bitwise
 
   def valid?(url, params, signature) do
     valid?(url, params, signature, Config.auth_token())


### PR DESCRIPTION
Fixes the warning:

```shell
warning: use Bitwise is deprecated. import Bitwise instead
  lib/ex_twilio/request_validator.ex:10: ExTwilio.RequestValidator
```