### PR TITLE
Adds media_url attribute to message resource.

### DIFF
--- a/lib/ex_twilio/resources/message.ex
+++ b/lib/ex_twilio/resources/message.ex
@@ -32,6 +32,7 @@ defmodule ExTwilio.Message do
             price_unit: nil,
             api_version: nil,
             uri: nil,
+            media_url: nil,
             subresource_uri: nil,
             messaging_service_sid: nil
 


### PR DESCRIPTION
Adds the media_url attribute to the message resource as specified in https://www.twilio.com/docs/messaging/api/message-resource

```
The URL of media to include in the Message content. jpeg, jpg, gif, and png file types are fully supported by Twilio and content is formatted for delivery on destination devices. The media size limit is 5 MB for supported file types (jpeg, jpg, png, gif) and 500 KB for [other types](https://www.twilio.com/docs/messaging/guides/accepted-mime-types)
 of accepted media. To send more than one image in the message, provide multiple media_url parameters in the POST request. You can include up to ten media_url parameters per message. [International](https://support.twilio.com/hc/en-us/articles/223179808-Sending-and-receiving-MMS-messages)
 and [carrier](https://support.twilio.com/hc/en-us/articles/223133707-Is-MMS-supported-for-all-carriers-in-US-and-Canada-)
 limits apply.
```

I tested sending a twilio message with a media_url and was able to verify that this indeed works. 

