### PR TITLE
Fix Elixir 1.17 warnings about fn parentheses

### DIFF
--- a/lib/ex_twilio/result_stream.ex
+++ b/lib/ex_twilio/result_stream.ex
@@ -39,7 +39,7 @@ defmodule ExTwilio.ResultStream do
   @spec fetch_page(url, module, options :: list) :: {list, {url, module, options :: list}}
   defp fetch_page(url, module, options) do
     results = Api.get!(url, Api.auth_header(options))
-    {:ok, items, meta} = Parser.parse_list(results, module, module.resource_collection_name)
+    {:ok, items, meta} = Parser.parse_list(results, module, module.resource_collection_name())
     {items, {next_page_url(meta["next_page_uri"]), module, options}}
   end
 

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -85,13 +85,13 @@ defmodule ExTwilio.UrlGenerator do
 
   defp add_segments(url, module, id, options) do
     # Append parents
-    url = url <> build_segments(:parent, normalize_parents(module.parents), options)
+    url = url <> build_segments(:parent, normalize_parents(module.parents()), options)
 
     # Append module segment
-    url = url <> segment(:main, {module.resource_name, id})
+    url = url <> segment(:main, {module.resource_name(), id})
 
     # Append any child segments
-    url <> build_segments(:child, module.children, options)
+    url <> build_segments(:child, module.children(), options)
   end
 
   @doc """
@@ -145,7 +145,7 @@ defmodule ExTwilio.UrlGenerator do
   @spec resource_collection_name(atom) :: String.t()
   def resource_collection_name(module) do
     module
-    |> resource_name
+    |> resource_name()
     |> Macro.underscore()
   end
 
@@ -184,10 +184,10 @@ defmodule ExTwilio.UrlGenerator do
   @spec build_query(atom, list) :: String.t()
   defp build_query(module, options) do
     special =
-      module.parents
+      module.parents()
       |> normalize_parents()
       |> Enum.map(fn parent -> parent.key end)
-      |> Enum.concat(module.children)
+      |> Enum.concat(module.children())
       |> Enum.concat([:token])
 
     query =
@@ -217,7 +217,7 @@ defmodule ExTwilio.UrlGenerator do
   defp segment(:main, {key, value}), do: "/#{inflect(key)}/#{value}"
 
   defp segment(:parent, {%ExTwilio.Parent{module: module, key: _key}, value}) do
-    "/#{module.resource_name}/#{value}"
+    "/#{module.resource_name()}/#{value}"
   end
 
   @spec inflect(String.t() | atom) :: String.t()


### PR DESCRIPTION
Fixes these runtime warnings:

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.ResultStreamTest.Resource.resource_collection_name() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/result_stream.ex:42: ExTwilio.ResultStream.fetch_page/3

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.ApiTest.Resource.parents() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:88: ExTwilio.UrlGenerator.add_segments/4

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.UrlGeneratorTest.Resource.resource_name() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:91: ExTwilio.UrlGenerator.add_segments/4

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.ResultStreamTest.Resource.children() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:94: ExTwilio.UrlGenerator.add_segments/4

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.ApiTest.Resource.parents() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:187: ExTwilio.UrlGenerator.build_query/2

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.UrlGeneratorTest.Resource.children() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:190: ExTwilio.UrlGenerator.build_query/2

    warning: using map.field notation (without parentheses) to invoke function ExTwilio.Account.resource_name() is deprecated, you must add parentheses instead: remote.function()
      (ex_twilio 0.10.0) lib/ex_twilio/url_generator.ex:220: ExTwilio.UrlGenerator.segment/2